### PR TITLE
fix: allow changesets action to create PRs and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -35,6 +37,6 @@ jobs:
           title: "chore: version packages"
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
- Use github.token instead of secrets.GITHUB_TOKEN for changesets
- Add fetch-depth: 0 to checkout for proper git history
- Permissions already set correctly (contents: write, pull-requests: write)

The GITHUB_TOKEN from secrets doesn't have sufficient permissions by default in some GitHub organizations. Using github.token respects the workflow's declared permissions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the Changesets action to create PRs and GitHub Releases by switching to github.token, which uses the workflow’s declared permissions. Also checkout with fetch-depth: 0 so Changesets has full git history.

<sup>Written for commit 4a0697a70df8a8d0a603e398dafb7a55089fbc72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated the release workflow to use `github.token` instead of `secrets.GITHUB_TOKEN` for the changesets action, which ensures the token respects the workflow's declared permissions (`contents: write`, `pull-requests: write`). Also added `fetch-depth: 0` to the checkout step to provide full git history, which is required by changesets to properly determine version bumps and changelog generation.

- Switched from `secrets.GITHUB_TOKEN` to `github.token` for better permission handling
- Added `fetch-depth: 0` to enable full git history access for changesets

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Both changes are standard best practices for GitHub Actions workflows with changesets: using `github.token` instead of `secrets.GITHUB_TOKEN` ensures proper permission inheritance, and `fetch-depth: 0` is required for changesets to access the full git history. The workflow already has the correct permissions declared. No functional logic changes or security concerns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Changed token reference from `secrets.GITHUB_TOKEN` to `github.token` and added `fetch-depth: 0` to checkout for full git history |

</details>



<sub>Last reviewed commit: 4a0697a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->