### PR TITLE
dep bump

### DIFF
--- a/.changeset/small-flies-slide.md
+++ b/.changeset/small-flies-slide.md
@@ -1,0 +1,5 @@
+---
+"repo-updater": patch
+---
+
+dep bump

--- a/bun.lock
+++ b/bun.lock
@@ -5,16 +5,16 @@
     "": {
       "name": "repo-updater",
       "dependencies": {
-        "@clack/prompts": "latest",
-        "better-result": "latest",
+        "@clack/prompts": "^1.1.0",
+        "better-result": "^2.7.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "latest",
-        "@changesets/cli": "latest",
-        "@types/bun": "latest",
-        "@typescript/native-preview": "latest",
-        "lefthook": "latest",
-        "ultracite": "latest",
+        "@biomejs/biome": "^2.4.6",
+        "@changesets/cli": "^2.30.0",
+        "@types/bun": "^1.3.10",
+        "@typescript/native-preview": "^7.0.0-dev.20260311.1",
+        "lefthook": "^2.1.3",
+        "ultracite": "^7.2.5",
       },
     },
   },
@@ -98,21 +98,21 @@
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260307.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260307.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260307.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260307.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260307.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260307.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260307.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260307.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-NcKdPiGjxxxdh7fLgRKTrn5hLntbt89NOodNaSrMChTfJwvLaDkgrRlnO7v5x+m7nQc87Qf1y7UoT1ZEZUBB4Q=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260311.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260311.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260311.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260311.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260311.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260311.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260311.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260311.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-BnyOW/mdZVZGevyeJ4RRY60CI4F121QBa++8Rwd+/Ms48OKQ30eMhaIKWGowz/u4WjJZmrzhFxIzN92XeSWMCQ=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260307.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VpnrMP4iDLSTT9Hg/KrHwuIHLZr5dxYPMFErfv3ZDA0tv48u2H1lBhHVVMMopCuskuX3C35EOJbxLkxCJd6zDw=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260311.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-k3UqlA40U9m8meAyliJdbTayDSGZRBGNsEDP2rtjOomLUo2IA0eIi4vNAjQKzsXFtyfoQ59MGAqOLSO/CzVrQA=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260307.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-+4akGPxwfrPy2AYmQO1bp6CXxUVlBPrL0lSv+wY/E8vNGqwF0UtJCwAcR54ae1+k9EmoirT7Xn6LE3Io6mXntg=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260311.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-8PNUCS1HPeXMK1F+1D3A4MyD+9Nil2mM3mWSwayUZpqT/A+dfEtcoo4Oe7Gz6qvMZbhCjbipwhTC84ilisiE1g=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260307.1", "", { "os": "linux", "cpu": "arm" }, "sha512-E0Pve6BjTVvPiHq9cPVQu6fbW/Qo/CEs1VN2NMILd0xzFVpVd9FIvzV+Ft6pZilu1SBcihThW3sQ92l03Cw2+Q=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260311.1", "", { "os": "linux", "cpu": "arm" }, "sha512-9T8kwNALCWzuNe00ri/f6wwoVD64YZW24cqkycFeptIF+DfNxfHMddWd7fvtHf0OKzPtkL83mkjBtviNeVKOfQ=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260307.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-u4kXuHN2p+HeWsnTixoEOwALsCoS+n3/ukWdnV/mwyg6BKuuU69qCv3/miY6YPFtE7mUwzPdflEXsvkZJbJ/RA=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260311.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WwRJO5ryMEs4Flro6JKNq0T+hR78eYFrItautu9o6EsIpeevk7Cq7T0BBgCrAf+A5aKts21HpiWzfHI0YP/CuQ=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260307.1", "", { "os": "linux", "cpu": "x64" }, "sha512-MzuRjTYQIS7XrJcH0As18SbaQU+rFhf9LCpXs2QeHjhXQ33wjuFDNhQeurg2eKm6A0xE0GoW9K+sKsm8bhzzPg=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260311.1", "", { "os": "linux", "cpu": "x64" }, "sha512-oMm3cb4njzMLBb61TI4EGq5Igxc+hoPHHNpMWqORfiYu/uQZWnter/twamTrZo6boCFtIa59mrGkhR3Qz7kauA=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260307.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-UNZl8Q6lx1njEPU8+FNjYvqii5PtDjk6cyxmVPwwJI2Snz5T5qY6oadkUds6CJsLkt7s4UB3P5XgLu1+vwoYGw=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260311.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-EQ5nz4qrwtzMZ5bjdMVQ2ke5BHQWDBz9IQsdh/8UU819cs5ZBnKmFFe5wOrIngqFvq4EoWKDXf983Vw0q4erkg=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260307.1", "", { "os": "win32", "cpu": "x64" }, "sha512-aPJb4v0Df9GzWFWbO4YbLg0OjmjxZgXngkF1M746r4CgOdydWgosNPWypzzAwiliGKvCLwfAWYiV+T5Jf1vQ3g=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260311.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Y/5A7BaRFV1Pro4BqNW3nVDuId7YdPXktl769x1yUjTDQLH6YJEJVeBkFkT0+4e1O5IL92rxxr8rWMLypNKnTw=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@biomejs/biome": "^2.4.6",
     "@changesets/cli": "^2.30.0",
     "@types/bun": "^1.3.10",
-    "@typescript/native-preview": "^7.0.0-dev.20260307.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260311.1",
     "lefthook": "^2.1.3",
     "ultracite": "^7.2.5"
   },


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pins previously "latest" dependencies and bumps versions to ensure reproducible installs. Upgrades `@typescript/native-preview` to ^7.0.0-dev.20260311.1 and adds a patch changeset.

- **Dependencies**
  - Pinned: `@clack/prompts` ^1.1.0, `better-result` ^2.7.0; dev: `@biomejs/biome` ^2.4.6, `@changesets/cli` ^2.30.0, `@types/bun` ^1.3.10, `lefthook` ^2.1.3, `ultracite` ^7.2.5.
  - Bumped: `@typescript/native-preview` ^7.0.0-dev.20260311.1 (with platform binaries updated in `bun.lock`).
  - Regenerated `bun.lock` and added a patch changeset for `repo-updater`.

<sup>Written for commit 86429b3fb0174ba7674340f46b7dcddc69f31d8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins all previously-`latest` dependency specifiers in `bun.lock` to match the semver ranges already present in `package.json`, and bumps the `@typescript/native-preview` nightly dev build from `7.0.0-dev.20260307.1` to `7.0.0-dev.20260311.1`. A changeset file is also added to mark this as a patch release.

Key points:
- **Dependency pinning**: The `bun.lock` workspace section previously recorded `latest` for all packages; it now matches the exact semver ranges in `package.json` (`^1.1.0`, `^2.7.0`, `^2.4.6`, etc.), which improves reproducibility.
- **`@typescript/native-preview` bump**: Updated to the March 11 nightly (`7.0.0-dev.20260311.1`) across all platform-specific optional packages with fresh checksums. This is a `devDependency` used for typechecking (`tsgo`), so the nightly cadence is expected.
- **Changeset description**: The PR title and changeset description (`dep bump`) are too vague for a meaningful changelog entry and do not follow the Conventional Commits standard enforced in this project — consider a more descriptive summary.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only bumps a nightly devDependency and pins lockfile versions with no runtime code changes.
- All changes are confined to the lockfile, package.json devDependencies, and a changeset file. No production source code is touched, the bumped package is a devDependency used only for typechecking, and the pinned checksums are consistent across all platform variants.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/small-flies-slide.md | New changeset file marking this as a patch release with description "dep bump" — description is minimal but functional. |
| package.json | Bumps @typescript/native-preview from the 20260307 nightly build to the 20260311 nightly build; all other pinned versions unchanged. |
| bun.lock | Lock file updated to reflect pinned semver ranges (replacing stale "latest" markers) and the bumped @typescript/native-preview nightly build with new checksums. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: dep bump] --> B[package.json]
    A --> C[bun.lock]
    A --> D[.changeset/small-flies-slide.md]

    B --> B1["@typescript/native-preview\n7.0.0-dev.20260307.1 → 7.0.0-dev.20260311.1"]

    C --> C1["Workspace deps: latest → pinned semver ranges"]
    C --> C2["@typescript/native-preview binaries\n(all platforms) updated to 20260311.1 with new checksums"]

    D --> D1["Marks release as patch\ndescription: 'dep bump'"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .changeset/small-flies-slide.md
Line: 5

Comment:
**Vague changeset description**

The description `dep bump` doesn't communicate which dependency was updated or why. Per the Conventional Commits standard enforced in this project, changeset summaries should be descriptive enough for changelog consumers to understand the change at a glance.

Consider something more informative:

```suggestion
bump `@typescript/native-preview` to nightly `7.0.0-dev.20260311.1`
```

**Rule Used:** Git standards. Enforces Conventional Commits and a... ([source](https://app.greptile.com/review/custom-context?memory=a0656d61-eb3c-4a7a-8913-760431ae60b9))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 86429b3</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Git standards. Enforces Conventional Commits and a... ([source](https://app.greptile.com/review/custom-context?memory=a0656d61-eb3c-4a7a-8913-760431ae60b9))

<!-- /greptile_comment -->