### PR TITLE
fix: replace insecure tmpdir paths with mkdtempSync

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -7,7 +7,7 @@ import {
   spyOn,
   test,
 } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Result } from "better-result";
@@ -73,7 +73,7 @@ const errResult = (message: string, command: string, stderr: string) =>
   );
 
 beforeEach(() => {
-  tempDir = join(tmpdir(), `cli-test-${Date.now()}`);
+  tempDir = mkdtempSync(join(tmpdir(), "cli-test-"));
   mkdirSync(join(tempDir, ".git"), { recursive: true });
   originalConsoleLog = console.log;
   console.log = consoleLogMock;

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig, validateRepos } from "../src/config.ts";
@@ -7,8 +7,7 @@ import { loadConfig, validateRepos } from "../src/config.ts";
 let tempDir: string;
 
 beforeEach(() => {
-  tempDir = join(tmpdir(), `repo-updater-test-${Date.now()}`);
-  mkdirSync(tempDir, { recursive: true });
+  tempDir = mkdtempSync(join(tmpdir(), "repo-updater-test-"));
 });
 
 afterEach(() => {

--- a/__tests__/runner.test.ts
+++ b/__tests__/runner.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Result } from "better-result";
@@ -23,8 +23,7 @@ let logSpy: ReturnType<typeof spyOn>;
 let warnSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
-  tempDir = join(tmpdir(), `repo-updater-runner-${Date.now()}`);
-  mkdirSync(tempDir, { recursive: true });
+  tempDir = mkdtempSync(join(tmpdir(), "repo-updater-runner-"));
   logSpy = spyOn(console, "log").mockImplementation(() => undefined);
   warnSpy = spyOn(console, "warn").mockImplementation(() => undefined);
 });


### PR DESCRIPTION
## Summary

- Resolves all 9 open CodeQL `js/insecure-temporary-file` alerts
- Replaces `join(tmpdir(), \`prefix-${Date.now()}\`) + mkdirSync(...)` with `mkdtempSync(join(tmpdir(), "prefix-"))` across all three test files
- `mkdtempSync` atomically creates a uniquely-named directory with a cryptographically random suffix, eliminating the TOCTOU race and symlink attack vectors that triggered the alerts

## Files changed

- `__tests__/config.test.ts` — 4 alerts resolved
- `__tests__/runner.test.ts` — 4 alerts resolved
- `__tests__/cli.test.ts` — 1 alert resolved

## Test plan

- [x] All 75 existing tests pass (`bun test`)
- [x] No new linting or type errors introduced
- [ ] CodeQL re-scan should close all 9 open alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced insecure temp directory creation in tests with mkdtempSync to eliminate CodeQL js/insecure-temporary-file alerts and block TOCTOU/symlink attacks. No production code changes.

- **Bug Fixes**
  - Swapped Date.now()-based temp paths for mkdtempSync(join(tmpdir(), "prefix-")) in `__tests__/config.test.ts`, `__tests__/runner.test.ts`, `__tests__/cli.test.ts`
  - Resolves 9 CodeQL alerts
  - All existing tests pass (bun test)

<sup>Written for commit d221f21618751a92ee5bec02e3be16031296c49d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves 9 CodeQL `js/insecure-temporary-file` alerts across three test files by replacing the racy `join(tmpdir(), \`prefix-${Date.now()}\`) + mkdirSync(...)` pattern with `mkdtempSync(join(tmpdir(), "prefix-"))`, which atomically creates a uniquely-named directory and eliminates both the TOCTOU race window and potential symlink attack vectors.

Key changes:
- **`__tests__/config.test.ts`**: Swapped to `mkdtempSync`; correctly dropped the now-redundant `mkdirSync(tempDir)` call in `beforeEach` while retaining the `mkdirSync` import for subdirectory creation elsewhere in the file.
- **`__tests__/runner.test.ts`**: Swapped to `mkdtempSync`; correctly removed `mkdirSync` entirely (both the import and the call) since it was only used for the temp dir itself, which `mkdtempSync` now handles.
- **`__tests__/cli.test.ts`**: Swapped to `mkdtempSync`; correctly kept `mkdirSync` imported and in use for creating `.git` subdirectories inside the temp dir.

All changes are minimal, accurate, and consistent with the intended fix. No logic errors or regressions were introduced.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a clean, targeted security fix with no functional changes to production code.
- All three call sites are correctly updated: mkdtempSync is used in place of the insecure pattern, redundant mkdirSync calls are removed where appropriate, and mkdirSync is retained where it is still needed for subdirectory creation. The changes are isolated to test files, all 75 tests pass, and there are no logic, syntax, or style issues introduced.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| __tests__/config.test.ts | Replaced Date.now()-based tmpdir creation with mkdtempSync; removed now-redundant mkdirSync call in beforeEach. mkdirSync is still correctly imported and used for subdirectory creation in the validateRepos test. |
| __tests__/runner.test.ts | Replaced Date.now()-based tmpdir creation with mkdtempSync and removed the now-unnecessary mkdirSync import and call. No remaining uses of mkdirSync in this file, so removing it from imports is correct. |
| __tests__/cli.test.ts | Replaced Date.now()-based tmpdir creation with mkdtempSync while correctly retaining mkdirSync (still needed for .git subdirectory creation on lines 77 and 261). Both old mkdirSync call sites for subdirs remain intact. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph OLD ["Before (Insecure — TOCTOU window)"]
        A1["join(tmpdir(), 'prefix-' + Date.now())"] --> B1["Path constructed (not yet on disk)"]
        B1 -->|"Race window: attacker can\ncreate/symlink the path"| C1["mkdirSync(path, {recursive: true})"]
        C1 --> D1["Directory used in tests"]
    end

    subgraph NEW ["After (Secure — atomic)"]
        A2["mkdtempSync(join(tmpdir(), 'prefix-'))"] --> B2["OS atomically creates dir\nwith random suffix"]
        B2 --> C2["Directory used in tests"]
    end

    OLD -.->|"PR fixes"| NEW
```

<sub>Reviews (1): Last reviewed commit: ["fix: replace insecure tmpdir paths with ..."](https://github.com/mynameistito/repo-updater/commit/d221f21618751a92ee5bec02e3be16031296c49d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26183240)</sub>

<!-- /greptile_comment -->