### PR TITLE
ci: add PR triage workflow

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,7 +1,10 @@
 name: PR Triage
 
 on:
-  pull_request:
+  # pull_request_target runs in the base-branch context so GITHUB_TOKEN retains
+  # write access even for fork PRs. The checkout step fetches the base branch
+  # (not the PR branch), so CODEOWNERS is always read from trusted code.
+  pull_request_target:
     types: [opened, reopened, ready_for_review]
 
 permissions:
@@ -18,21 +21,41 @@ jobs:
       - name: Parse CODEOWNERS for default owner
         id: owner
         run: |
-          OWNER=$(grep -E '^\*\s+' .github/CODEOWNERS | awk '{print $2}' | sed 's/@//')
-          if [ -z "$OWNER" ]; then
+          RAW_OWNER=$(grep -E '^\*\s+' .github/CODEOWNERS | awk '{print $2}')
+          if [ -z "$RAW_OWNER" ]; then
             echo "::error::Could not determine CODEOWNER from .github/CODEOWNERS"
             exit 1
           fi
-          echo "username=$OWNER" >> $GITHUB_OUTPUT
+          echo "raw_owner=$RAW_OWNER" >> "$GITHUB_OUTPUT"
 
       - name: Request CODEOWNER as reviewer if none assigned
-        if: ${{ toJson(github.event.pull_request.requested_reviewers) == '[]' }}
+        if: ${{ toJson(github.event.pull_request.requested_reviewers) == '[]' && toJson(github.event.pull_request.requested_teams) == '[]' }}
         uses: actions/github-script@v7
+        env:
+          RAW_OWNER: ${{ steps.owner.outputs.raw_owner }}
         with:
           script: |
-            await github.rest.pulls.requestReviewers({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              reviewers: ['${{ steps.owner.outputs.username }}']
-            })
+            const rawOwner = process.env.RAW_OWNER;
+            const ownerStr = rawOwner.replace(/^@/, '');
+            const isTeam = ownerStr.includes('/');
+
+            if (isTeam) {
+              const teamSlug = ownerStr.split('/')[1];
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                team_reviewers: [teamSlug]
+              });
+            } else {
+              if (ownerStr === context.payload.pull_request.user.login) {
+                console.log('Skipping: CODEOWNER is the PR author');
+                return;
+              }
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                reviewers: [ownerStr]
+              });
+            }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-triage.yml` to auto-request the CODEOWNER as reviewer on new PRs
- Triggers on `opened`, `reopened`, and `ready_for_review` events
- Skips draft PRs via a job-level condition
- Only assigns a reviewer if none are already requested
- Mirrors the existing `issue-triage.yml` pattern for consistency

## Test plan

- [x] Open a new PR and verify CODEOWNER is requested as reviewer
- [ ] Open a draft PR and verify no reviewer is assigned until marked ready
- [x] Open a PR with a reviewer already assigned and verify no duplicate is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PR triage workflow that auto-requests the default CODEOWNER (user or team) on new PRs, skipping drafts and avoiding duplicates. Uses `pull_request_target` so fork PRs get assigned reviewers and CODEOWNERS is read from the base branch.

- **New Features**
  - Runs on opened, reopened, and ready_for_review via `pull_request_target`.
  - Supports CODEOWNER teams and users; checks both requested reviewers and teams before assigning.

- **Bug Fixes**
  - Prevents script injection by passing the parsed owner via env to `actions/github-script`.
  - Skips assignment when the CODEOWNER is the PR author to avoid 422 errors.

<sup>Written for commit 85c68bacbe3cdbe5980b9067818d6a37b2f219b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `.github/workflows/pr-triage.yml`, a new CI workflow that auto-requests the default CODEOWNER as a reviewer on new PRs. It mirrors the existing `issue-triage.yml` pattern and fits naturally into the repo's automation layer.

Both prior critical concerns from the review thread have been properly resolved:

- **Script injection** — the step output is now passed via an `env:` block and consumed through `process.env.RAW_OWNER` in the JavaScript step, eliminating any expression-interpolation injection vector.
- **Fork PR 403** — the trigger has been updated from `pull_request` to `pull_request_target`, which runs in the base-branch context and preserves `GITHUB_TOKEN` write access for fork-originated PRs. The `actions/checkout@v4` step uses the default ref (base branch HEAD), so `.github/CODEOWNERS` is always read from trusted code — this is both correct and clearly documented in the inline comment.

Additional improvements over `issue-triage.yml`:
- `$GITHUB_OUTPUT` is properly quoted (`>> "$GITHUB_OUTPUT"`) to avoid word-splitting.
- The condition checks both `requested_reviewers` and `requested_teams` arrays before assigning.
- Team-slug owners (e.g. `@org/team`) are handled separately from individual owners.
- A self-review guard prevents requesting a review from the PR author when they are the CODEOWNER.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — both previously raised critical issues are fully resolved and no new issues were found.
- The two blocking concerns from the prior review (script injection via step-output interpolation and fork-PR write permission denial) are both correctly addressed in this revision. The `pull_request_target` trigger with a base-branch checkout is the right security posture, the env-var approach for the step output eliminates the injection surface, and the additional guards (team owners, self-review skip, duplicate-reviewer check) are all implemented correctly. No new issues were identified.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr-triage.yml | New workflow that auto-assigns CODEOWNER as PR reviewer; properly uses `pull_request_target`, env-var injection guard, team-reviewer support, and self-review skip. Both prior critical concerns (script injection, fork 403) are fully addressed. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub
    participant Runner as Actions Runner
    participant CO as CODEOWNERS (base branch)
    participant API as GitHub REST API

    GH->>Runner: pull_request_target fired<br/>(opened / reopened / ready_for_review)
    Runner->>Runner: Skip if draft == true
    Runner->>CO: checkout@v4 (base branch, no PR code)
    CO-->>Runner: raw_owner from grep/awk
    Runner->>Runner: Evaluate condition:<br/>requested_reviewers == [] &&<br/>requested_teams == []
    alt No reviewers assigned yet
        Runner->>Runner: Read RAW_OWNER via process.env<br/>(no expression injection)
        alt Team owner (contains "/")
            Runner->>API: pulls.requestReviewers(team_reviewers: [teamSlug])
        else Individual owner == PR author
            Runner->>Runner: Skip (self-review guard)
        else Individual owner
            Runner->>API: pulls.requestReviewers(reviewers: [username])
        end
        API-->>GH: Reviewer requested ✓
    else Reviewers already assigned
        Runner->>Runner: Step skipped — no duplicate added
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix: address pr-triage workflow review f..."](https://github.com/mynameistito/repo-updater/commit/85c68bacbe3cdbe5980b9067818d6a37b2f219b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26195738)</sub>

<!-- /greptile_comment -->