### PR TITLE
fix: improve PR labeler accuracy with granular file patterns

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,8 +18,14 @@ github-config:
       - any-glob-to-any-file:
           - ".github/ISSUE_TEMPLATE/**"
           - ".github/PULL_REQUEST_TEMPLATE.md"
+          - ".github/PULL_REQUEST_TEMPLATE/**"
           - ".github/labeler.yml"
           - ".github/settings.yml"
+          - ".github/dependabot.yml"
+          - ".github/CODEOWNERS"
+          - ".github/FUNDING.yml"
+          - ".github/renovate.json"
+          - ".github/renovate.json5"
 
 source:
   - changed-files:


### PR DESCRIPTION
## Summary
- Rewrites `.github/labeler.yml` with more precise file globs
- Adds `pnpm-lock.yaml` and `yarn.lock` to `dependencies`
- Scopes `ci` to `.github/workflows/**` only (was `.github/**`)
- Adds new `github-config` label for templates/settings
- Adds new `scripts` label for `scripts/**`
- Adds new `changeset` label for `.changeset/**`
- Moves `vitest.config.ts` from `configuration` to `tests`
- Removes `*.md` catch-all from `documentation` (was catching changesets)

Fixes #49

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote `.github/labeler.yml` with granular patterns and tighter scopes to improve label accuracy and cover common `.github` config files. This prevents mislabels for docs/tests/CI and avoids unlabeled GitHub config changes.

- **Bug Fixes**
  - Dependencies: include `pnpm-lock.yaml`, `yarn.lock`.
  - CI: restrict to `.github/workflows/**`.
  - Labels and GitHub config: add `github-config`, `scripts`, `changeset`; include `.github/ISSUE_TEMPLATE/**`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/PULL_REQUEST_TEMPLATE/**`, `.github/labeler.yml`, `.github/settings.yml`, `.github/dependabot.yml`, `.github/CODEOWNERS`, `.github/FUNDING.yml`, `.github/renovate.json`, `.github/renovate.json5`.
  - Tests: include `vitest.config.ts`, `**/*.test.ts`, `**/*.spec.ts`.
  - Docs: replace `*.md` catch-all with explicit files (`README.md`, `CHANGELOG.md`, etc.) and `docs/**` to avoid `.changeset/**`.

<sup>Written for commit b87d7fb87d653c5f3e67445dbfcb5ffeca25de4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewrites `.github/labeler.yml` with more precise file glob patterns to reduce mislabeling across all label categories. The changes are well-scoped and directly address issue #49 (changesets being incorrectly labeled as documentation due to the `*.md` catch-all).

Key changes:
- `dependencies`: adds `pnpm-lock.yaml` and `yarn.lock` to cover popular package managers.
- `ci`: narrowed from `.github/**` to `.github/workflows/**` only.
- `github-config` (new): explicitly lists common `.github/` config files (`dependabot.yml`, `CODEOWNERS`, `FUNDING.yml`, `renovate.json/json5`, templates, `labeler.yml`, `settings.yml`), directly addressing the gap flagged in a prior review thread.
- `tests`: gains `vitest.config.ts`, `**/*.test.ts`, and `**/*.spec.ts` patterns.
- `documentation`: drops the `*.md` / `README.*` catch-alls in favour of an explicit allowlist plus `docs/**`, eliminating the `.changeset/**` mislabeling.
- `scripts` and `changeset` (new): dedicated labels for `scripts/**` and `.changeset/**` respectively.
- `configuration`: cleaned up by removing the now-moved entries.

No functional or runtime concerns — this is a pure YAML configuration change to a GitHub Actions labeler. The changes are consistent, intentional, and well-documented in the PR description.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — pure YAML config change with no runtime impact, all prior concerns addressed.
- The change is limited to a single YAML labeler config file. The logic is sound, all label categories are internally consistent, and the previously flagged concern about unlabelled `.github/` files has been explicitly handled in the new `github-config` label. No breaking changes or edge-case bugs identified.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/labeler.yml | Complete rewrite of labeler config with granular file globs; adds github-config, scripts, and changeset labels, scopes ci to workflows only, fixes documentation catch-all, and explicitly addresses the previously flagged unlabelled .github/ files concern. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[PR File Changes] --> W{".github/workflows/**?"}
    PR --> GC{".github/ config files?"}
    PR --> SRC{"src/**?"}
    PR --> TEST{"__tests__/** or *.test.ts / *.spec.ts?"}
    PR --> DOC{"README.md, CHANGELOG.md, docs/**?"}
    PR --> DEP{"package.json, *-lock.yaml, bun.lock?"}
    PR --> CFG{"tsconfig*.json, biome.jsonc, lefthook.yml?"}
    PR --> SCR{"scripts/**?"}
    PR --> CS{".changeset/**?"}

    W -->|yes| CI[🏷️ ci]
    GC -->|yes| GHCFG[🏷️ github-config]
    SRC -->|yes| SOURCE[🏷️ source]
    TEST -->|yes| TESTS[🏷️ tests]
    DOC -->|yes| DOCS[🏷️ documentation]
    DEP -->|yes| DEPS[🏷️ dependencies]
    CFG -->|yes| CONFIGURATION[🏷️ configuration]
    SCR -->|yes| SCRIPTS[🏷️ scripts]
    CS -->|yes| CHANGESET[🏷️ changeset]
```

<sub>Reviews (2): Last reviewed commit: ["fix: add missing github config files to ..."](https://github.com/mynameistito/repo-updater/commit/b87d7fb87d653c5f3e67445dbfcb5ffeca25de4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26263671)</sub>

<!-- /greptile_comment -->