### PR TITLE
rm minimatch override

### DIFF
--- a/.changeset/eighty-coats-tell.md
+++ b/.changeset/eighty-coats-tell.md
@@ -1,0 +1,5 @@
+---
+"repo-updater": patch
+---
+
+rm minimatch override, no longer needed was added due to CVE

--- a/bun.lock
+++ b/bun.lock
@@ -20,9 +20,6 @@
       },
     },
   },
-  "overrides": {
-    "minimatch": "^10.2.3",
-  },
   "packages": {
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,5 @@
     "ultracite": "^7.3.2",
     "vitest": "^4.1.1"
   },
-  "overrides": {
-    "minimatch": "^10.2.3"
-  }
+  "overrides": {}
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the temporary `minimatch` override that was added for a CVE. Cleaned up `package.json` and `bun.lock` by dropping the override and leaving `overrides` empty in `repo-updater`.

<sup>Written for commit 67b317593ebf8e390fd46a0e8cde0c21640f62d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `minimatch` dependency override that was previously pinned to `^10.2.3` as a CVE mitigation. Now that the CVE has been addressed upstream, the override is no longer needed — `minimatch` naturally resolves to `10.2.4` via `glob`'s transitive dependency range (`^10.2.2`), which is at or above the previously enforced floor.

- Removed `minimatch: ^10.2.3` from `overrides` in both `package.json` and `bun.lock`
- `minimatch` still resolves to `10.2.4` in the lockfile, confirming the CVE-safe version is still in use
- Added a changeset entry (`patch`) documenting the removal
- Minor: `"overrides": {}` is left as an empty object in `package.json` instead of being fully removed

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the resolved minimatch version (10.2.4) still meets the CVE-safe threshold that was originally enforced by the override.
- The change is a straightforward cleanup: the override is gone but the lockfile confirms minimatch still resolves to 10.2.4, equal to or above the 10.2.3 floor that was the reason for the override. No functional code is touched, only dependency configuration.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/eighty-coats-tell.md | New changeset file documenting the removal of the minimatch override as a patch release. |
| package.json | Removes `minimatch: ^10.2.3` from `overrides`; leaves an empty `overrides: {}` object which is harmless but unnecessary. |
| bun.lock | Removes the `overrides` section from the lockfile; minimatch naturally resolves to `10.2.4` (via glob's `^10.2.2` dep range), which satisfies the previously-overridden `^10.2.3` floor. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json] -->|overrides removed| B{minimatch resolution}
    B -->|glob dep range 10.2.2+| C[minimatch 10.2.4]
    C -->|satisfies CVE-safe floor 10.2.3| D[Secure - no override needed]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: package.json
Line: 65

Comment:
**Empty `overrides` object can be removed**

The `minimatch` override was removed but the `overrides` key is left as an empty object `{}`. While harmless, it adds noise to `package.json`. Consider removing it entirely to keep the file clean.

```suggestion
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["rm minimatch override no longer needed"](https://github.com/mynameistito/repo-updater/commit/67b317593ebf8e390fd46a0e8cde0c21640f62d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26279151)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->