### PR TITLE
cve bumps

### DIFF
--- a/.changeset/bold-hounds-cheat.md
+++ b/.changeset/bold-hounds-cheat.md
@@ -1,0 +1,5 @@
+---
+"repo-updater": patch
+---
+
+cve bumps

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,9 @@
     },
   },
   "overrides": {
+    "brace-expansion": ">=5.0.5",
     "minimatch": "^10.2.3",
+    "picomatch": ">=4.0.4",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -287,7 +289,7 @@
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.2", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw=="],
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -561,7 +563,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
@@ -690,8 +692,6 @@
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
-
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "vitest": "^4.1.2"
   },
   "overrides": {
-    "minimatch": "^10.2.3"
+    "minimatch": "^10.2.3",
+    "brace-expansion": ">=5.0.5",
+    "picomatch": ">=4.0.4"
   }
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CVE alerts by updating dependency overrides for `brace-expansion` and `picomatch`, and enforcing a safe `minimatch` version. No runtime changes expected.

- **Dependencies**
  - Add overrides: `brace-expansion@>=5.0.5`, `picomatch@>=4.0.4`
  - Keep `minimatch@^10.2.3` enforced
  - Update lockfile to `brace-expansion@5.0.5` and `picomatch@4.0.4`

<sup>Written for commit 48497c0b579fbddbc36b579d03838ace4ea583ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps two transitive dependencies to address recent CVEs: `brace-expansion` is updated from `5.0.2` to `5.0.5` (fixing CVE-2026-33750, an infinite-loop DoS) and `picomatch` from `4.0.3` to `4.0.4` (fixing CVE-2026-33672, a method-injection vulnerability). Both overrides are declared in `package.json` and resolved in `bun.lock`.

- **brace-expansion bump (5.0.2 → 5.0.5)**: Correctly addresses CVE-2026-33750. No compatibility concerns.
- **picomatch override (`>=4.0.4`)**: Fixes CVE-2026-33672 for packages already on the v4 line (`vite`, `vitest`, `tinyglobby`), but also forces `micromatch@4.0.8` — which declares `picomatch: "^2.3.1"` — to use picomatch v4. The old nested `micromatch/picomatch@2.3.1` lock entry was removed with no replacement at v2. Since CVE-2026-33672 is patched in v2.3.2 as well, a less disruptive override such as `"picomatch": "^2.3.2"` would fix the vulnerability for `micromatch` without crossing a major-version boundary.
- **Changeset**: Correctly categorized as a `patch` release.

<h3>Confidence Score: 4/5</h3>

Safe to merge with low-to-medium risk; CVEs are addressed but the picomatch override applies a major-version jump to micromatch which could cause subtle glob-matching regressions.

The brace-expansion bump is clean and correct. The picomatch override resolves CVE-2026-33672, but using >=4.0.4 globally forces micromatch@4 (which expects picomatch@^2.x) onto picomatch v4, a two-major-version jump with documented behavioral differences. This is a P1 concern that warrants revisiting before merge.

package.json and bun.lock — specifically the picomatch override and the removal of the micromatch/picomatch@2.x nested resolution.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/bold-hounds-cheat.md | New changeset file marking this as a patch release for CVE dependency bumps — no issues. |
| bun.lock | brace-expansion bumped 5.0.2→5.0.5 (CVE-2026-33750 fix) and picomatch bumped 4.0.3→4.0.4 (CVE-2026-33672 fix); the nested micromatch/picomatch@2.3.1 entry was removed, causing micromatch@4 to use picomatch v4 instead of the v2.x it was designed for. |
| package.json | Adds overrides for brace-expansion (>=5.0.5) and picomatch (>=4.0.4); the picomatch override forces a v4 resolution onto micromatch@4 which expects ^2.3.1, creating a major-version mismatch. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    OV["package.json overrides"]
    OV -->|"brace-expansion >=5.0.5"| BE["brace-expansion@5.0.5\n✅ CVE-2026-33750 fixed"]
    OV -->|"picomatch >=4.0.4"| PM4["picomatch@4.0.4\n✅ CVE-2026-33672 fixed"]
    OV -->|"minimatch ^10.2.3"| MM["minimatch@10.2.3"]
    PM4 -->|"used by (peer: ^3 || ^4)"| FDIR["fdir@6.5.0"]
    PM4 -->|"used by (expects ^4.0.3)"| TG["tinyglobby@0.2.15"]
    PM4 -->|"used by (expects ^4.0.3)"| VITE["vite@7.3.1"]
    PM4 -->|"used by (expects ^4.0.3)"| VITEST["vitest@4.1.2"]
    PM4 -->|"⚠️ forced by override\nexpects ^2.3.1"| MICRO["micromatch@4.0.8"]
    MICRO -->|"used by"| CS1["@changesets/config"]
    MICRO -->|"used by"| CS2["@changesets/git"]
    MICRO -->|"used by"| FG["fast-glob@3.3.3"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: package.json
Line: 67-68

Comment:
**Major version mismatch: micromatch@4 gets picomatch@4 instead of v2**

`micromatch@4.0.8` declares a dependency on `picomatch: "^2.3.1"`, but the global `picomatch: ">=4.0.4"` override (reflected in `bun.lock` by the removal of the `micromatch/picomatch` nested entry) forces it to use picomatch v4 instead. picomatch underwent significant behavioral changes between v2 and v4 — for example, there is a documented difference where v4's `**` globstar is more aggressive and can match the pattern itself, causing infinite recursion in tools like `npm-run-all`. This could produce subtle glob-matching regressions in any code path that reaches `micromatch` (e.g. `@changesets/config` and `@changesets/git`, which both depend on `micromatch: "^4.0.8"`).

CVE-2026-33672 was patched across all three active branches: v2.3.2, v3.0.2, and v4.0.4. A safer fix that avoids the major-version mismatch for `micromatch` would be to constrain the override to the v2 patch:

```json
"overrides": {
  "minimatch": "^10.2.3",
  "brace-expansion": ">=5.0.5",
  "picomatch": "^2.3.2"
}
```

This would let `micromatch` stay on picomatch v2 (patched), while packages that already declare `picomatch@^3 || ^4` (e.g. `vite`, `vitest`, `tinyglobby`) would still be resolved at their declared ranges rather than being overridden to a version outside what they expect.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["cve bumps"](https://github.com/mynameistito/repo-updater/commit/48497c0b579fbddbc36b579d03838ace4ea583ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26646258)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->