### PR TITLE
fix biome HTML formatter not idempotent

### DIFF
--- a/assets/social-preview.html
+++ b/assets/social-preview.html
@@ -425,9 +425,8 @@
             <div class="terminal-title">bash — repo-updater</div>
           </div>
           <div class="terminal-body">
-            <!-- prettier-ignore -->
-            <pre
-            ><span class="prompt">$</span> <span class="cmd">repo-updater</span>
+            <pre>
+<span class="prompt">$</span> <span class="cmd">repo-updater</span>
 
 <span class="step">  ◆ Processing </span><span class="white">3 repositories</span>
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,8 +3,5 @@
   "extends": ["ultracite/biome/core"],
   "javascript": {
     "globals": ["Bun", "Deno"]
-  },
-  "files": {
-    "includes": ["!assets"]
   }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- A short summary of the change and why it was made. -->
Fixes: https://github.com/mynameistito/repo-updater/issues/69
Fixes: https://github.com/haydenbleasel/ultracite/issues/617

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / CI / tooling

## Related issue

<!-- Every PR must be linked to an issue. If one doesn't exist yet, open one first. -->

Closes #

## Checklist

- [ ] Tests added or updated
- [x] `bun test` and `bun run test:node` pass
- [x] `bun run typecheck` passes
- [ ] Changeset added (`bunx changeset`) — or this PR is non-user-facing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an idempotency issue with Biome's HTML formatter by removing the `!assets` exclusion from `biome.jsonc` and reformatting `assets/social-preview.html` to match what Biome now produces. The `<!-- prettier-ignore -->` comment and the unusual `<pre
            >` trick are replaced with a standard `<pre>` tag followed by a newline — which is safe per the HTML spec, as browsers strip the first newline inside a `<pre>` element.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a formatting fix with no behavioral or functional changes.

Both changes are cosmetic/tooling only. The HTML rendering is unaffected (HTML spec guarantees the first newline after `<pre>` is stripped), and removing the Biome exclusion is the correct fix for the idempotency issue. No P0/P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| biome.jsonc | Removes the `files.includes: ["!assets"]` exclusion so Biome now formats files in the `assets` directory, enabling idempotent HTML formatting. |
| assets/social-preview.html | Replaces the Prettier-ignore workaround and `<pre\n>` trick with a standard `<pre>` open tag; the leading newline is stripped by browsers per the HTML spec, so rendering is unchanged. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer runs Biome formatter] --> B{assets/ excluded?}
    B -- "Before PR: Yes (excluded)" --> C[social-preview.html skipped]
    C --> D[File stays in non-Biome format]
    D --> E[Next Biome run would still want to change it → not idempotent]
    B -- "After PR: No (included)" --> F[Biome formats social-preview.html]
    F --> G[File matches Biome output]
    G --> H[Subsequent runs produce no diff → idempotent ✔]
```

<sub>Reviews (1): Last reviewed commit: ["chore: fix biome html formatter notidepo..."](https://github.com/mynameistito/repo-updater/commit/417f090cca3f28728b5752c93aacbbbf8d480190) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27968855)</sub>

<!-- /greptile_comment -->