### PR TITLE
OC Install

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode-go/mimo-v2-omni


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Installs an `opencode` GitHub Action that runs when someone comments `/oc` or `/opencode` on issues or PR review threads. This adds a simple slash-command to trigger OpenCode automation.

- **New Features**
  - Triggers on new `issue_comment` and `pull_request_review_comment` containing or starting with `/oc` or `/opencode`.
  - Runs `anomalyco/opencode/github@latest` with model `opencode-go/mimo-v2-omni`.
  - Uses `OPENCODE_API_KEY` secret; repo permissions are read-only (with `id-token` write).

<sup>Written for commit e3c6d128c18d0f9318f88a111d966e971d3ca2a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new GitHub Actions workflow that enables an `opencode` slash-command bot triggered by `/oc` or `/opencode` comments on issues and PRs.

- **P1**: `anomalyco/opencode/github@latest` is unpinned — any future push to that tag runs automatically in CI with access to `OPENCODE_API_KEY` and OIDC token issuance rights, creating a direct supply chain attack vector.
- **P1**: `id-token: write` is present but appears unnecessary; no other workflow in this repo uses it, and granting it amplifies the risk from the unpinned action above.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the unpinned third-party action is pinned to a commit SHA and the unnecessary id-token:write permission is removed.

Two P1 security findings: an unpinned external action with floating @latest combined with id-token:write creates a concrete supply chain and credential-exfiltration risk. Both must be addressed before merging.

.github/workflows/opencode.yml requires attention — specifically lines 18 and 29.

<details open><summary><h3>Security Review</h3></summary>

- **Supply chain risk** (`.github/workflows/opencode.yml` line 29): `anomalyco/opencode/github@latest` is an unpinned floating tag. Any update to the upstream action runs automatically with access to `OPENCODE_API_KEY` and OIDC token issuance rights.
- **Overly broad OIDC permission** (`.github/workflows/opencode.yml` line 18): `id-token: write` grants the workflow (and all steps within it, including the unpinned action) the ability to mint OIDC tokens that can authenticate to cloud providers. This permission is absent from every other workflow in this repository and appears unnecessary.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/opencode.yml | New workflow adding a slash-command-triggered opencode bot; has two P1 security issues: unpinned third-party action at @latest and unnecessary id-token:write permission |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant GitHub
    participant Workflow as opencode.yml Workflow
    participant OC as anomalyco/opencode/github@latest
    participant API as opencode API

    User->>GitHub: Posts comment with /oc or /opencode
    GitHub->>Workflow: Triggers issue_comment / pull_request_review_comment event
    Workflow->>Workflow: Evaluates if condition
    Workflow->>OC: Run opencode action
    Note over OC: Runs with OPENCODE_API_KEY + id-token:write
    OC->>API: Sends prompt / model request
    API-->>OC: Returns response
    OC-->>GitHub: Posts result
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/opencode.yml
Line: 18

Comment:
**`id-token: write` appears unnecessary and overly permissive**

No other workflow in this repo requests `id-token: write`. This permission lets any step (including the unpinned `anomalyco/opencode/github@latest` action) mint OIDC tokens that can authenticate to cloud providers (AWS, GCP, Azure) configured to trust this repository. Unless opencode explicitly needs cloud provider federation via OIDC, remove this permission to reduce the blast radius of a compromised action.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/opencode.yml
Line: 29

Comment:
**Unpinned third-party action is a supply chain risk**

`anomalyco/opencode/github@latest` resolves to whatever the maintainer pushes at any time, so a malicious or accidental update automatically runs in your CI with access to `OPENCODE_API_KEY` and the `id-token: write` capability. Pin the action to a specific immutable commit SHA so changes require an explicit, reviewable bump in this file.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/opencode.yml
Line: 12-15

Comment:
**`/oc` trigger pattern is too broad and may fire unintentionally**

`startsWith(github.event.comment.body, '/oc')` also matches `/octopus`, `/octocat`, or any other slash command starting with `/oc`. Consider tightening the pattern to require a word boundary, e.g. `startsWith(github.event.comment.body, '/oc ')` to prevent unintended triggers.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/opencode.yml
Line: 20-21

Comment:
**Missing write permissions for comment/PR response**

If opencode needs to post a reply back to the triggering comment or update issue/PR state via the `GITHUB_TOKEN`, the current `read`-only permissions for `pull-requests` and `issues` will result in a 403. Other response-writing workflows in this repo (e.g. `issue-triage.yml`, `pr-triage.yml`) use `write` for the relevant scope. Confirm whether the action posts back exclusively through `OPENCODE_API_KEY`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: install oc"](https://github.com/mynameistito/repo-updater/commit/e3c6d128c18d0f9318f88a111d966e971d3ca2a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28145812)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->