### PR TITLE
fix: hide Windows console window when opening URLs, fix UAC from bun shebang

### DIFF
--- a/.changeset/brave-fox-ember.md
+++ b/.changeset/brave-fox-ember.md
@@ -1,0 +1,5 @@
+---
+"repo-updater": patch
+---
+
+Add ENOENT guard and actionable diagnostic when Node.js re-exec fails on Windows. Emit a clear stderr message suggesting `npm i -g repo-updater` or installing Node.js when `node` is not found on PATH. Handle null exit code from signal-killed processes. Add inline comment in `openURLs` explaining why all URL-open commands route through `openURLNodejs` unconditionally to prevent UAC prompts under Bun on Windows.

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -380,6 +380,7 @@ describe("main", () => {
         {
           stdout: "ignore",
           stderr: "ignore",
+          windowsHide: true,
         }
       );
     } finally {
@@ -402,6 +403,7 @@ describe("main", () => {
         {
           stdout: "ignore",
           stderr: "ignore",
+          windowsHide: true,
         }
       );
     } finally {
@@ -433,6 +435,7 @@ describe("main", () => {
         {
           stdout: "ignore",
           stderr: "ignore",
+          windowsHide: true,
         }
       );
     } finally {
@@ -457,12 +460,12 @@ describe("main", () => {
       expect(spawnSpy).toHaveBeenNthCalledWith(
         1,
         ["cmd", "/c", "start", "", "https://example.com/1"],
-        { stdout: "ignore", stderr: "ignore" }
+        { stdout: "ignore", stderr: "ignore", windowsHide: true }
       );
       expect(spawnSpy).toHaveBeenNthCalledWith(
         2,
         ["cmd", "/c", "start", "", "https://example.com/2"],
-        { stdout: "ignore", stderr: "ignore" }
+        { stdout: "ignore", stderr: "ignore", windowsHide: true }
       );
     } finally {
       spawnSpy.mockRestore();
@@ -506,7 +509,7 @@ describe("main", () => {
           "https://example.com/1",
           "https://example.com/2",
         ],
-        { stdout: "ignore", stderr: "ignore" }
+        { stdout: "ignore", stderr: "ignore", windowsHide: true }
       );
     } finally {
       spawnSpy.mockRestore();
@@ -542,6 +545,7 @@ describe("main", () => {
         {
           stdout: "ignore",
           stderr: "ignore",
+          windowsHide: true,
         }
       );
     } finally {
@@ -568,6 +572,7 @@ describe("main", () => {
         {
           stdout: "ignore",
           stderr: "ignore",
+          windowsHide: true,
         }
       );
     } finally {
@@ -590,6 +595,7 @@ describe("main", () => {
         {
           stdout: "ignore",
           stderr: "ignore",
+          windowsHide: true,
         }
       );
     } finally {
@@ -617,7 +623,7 @@ describe("main", () => {
           "https://example.com/1",
           "https://example.com/2",
         ],
-        { stdout: "ignore", stderr: "ignore" }
+        { stdout: "ignore", stderr: "ignore", windowsHide: true }
       );
     } finally {
       spawnSpy.mockRestore();
@@ -642,6 +648,7 @@ describe("main", () => {
       expect(spawnSpy).toHaveBeenCalledWith(["open", "https://example.com"], {
         stdout: "ignore",
         stderr: "ignore",
+        windowsHide: true,
       });
     } finally {
       spawnSpy.mockRestore();

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -8,10 +8,10 @@ import {
   spyOn,
   test,
 } from "bun:test";
+import { spawn as realSpawn } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { spawn as realSpawn } from "node:child_process";
 import { Result } from "better-result";
 import { CommandFailedError } from "../src/errors.ts";
 import type { RepoResult } from "../src/runner.ts";

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -1,4 +1,5 @@
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -10,6 +11,7 @@ import {
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawn as realSpawn } from "node:child_process";
 import { Result } from "better-result";
 import { CommandFailedError } from "../src/errors.ts";
 import type { RepoResult } from "../src/runner.ts";
@@ -49,6 +51,27 @@ const isCancelMock = mock((_val: unknown) => false);
 
 /** Mock replacing `console.log` to suppress output during tests. */
 const consoleLogMock = mock(noop);
+
+// Capture the real function value BEFORE mock.module overwrites the live
+// ES-module binding — otherwise `realSpawn` inside the closure would point
+// back to `spawnMock` and recurse infinitely.
+const capturedSpawn = realSpawn;
+
+/** Mock for `node:child_process` `spawn`.
+ * Intercepts fire-and-forget calls from `openURLNodejs` (stdio: "ignore").
+ * Delegates to the real spawn for all other callers (e.g. `execNodejs`). */
+const spawnMock = mock(
+  (cmd: string, args: string[], opts?: Parameters<typeof realSpawn>[2]) => {
+    if (opts && "stdio" in opts && opts.stdio === "ignore") {
+      return { unref: mock(noop) } as unknown as ReturnType<typeof realSpawn>;
+    }
+    return capturedSpawn(cmd, args, opts as Parameters<typeof realSpawn>[2]);
+  }
+);
+
+mock.module("node:child_process", () => ({
+  spawn: spawnMock,
+}));
 
 mock.module("@clack/prompts", () => ({
   intro: mock(noop),
@@ -107,11 +130,18 @@ beforeEach(() => {
   spinnerInstance.start.mockClear();
   spinnerInstance.stop.mockClear();
   isCancelMock.mockClear();
+  spawnMock.mockClear();
 });
 
 afterEach(() => {
   console.log = originalConsoleLog;
   rmSync(tempDir, { recursive: true, force: true });
+});
+
+// Restore the real node:child_process after all cli tests so later test files
+// (e.g. runner.test.ts) are not affected by the module-level mock.
+afterAll(() => {
+  mock.module("node:child_process", () => ({ spawn: realSpawn }));
 });
 
 describe("printUsage", () => {
@@ -311,19 +341,12 @@ describe("main", () => {
       okResult(opts.repo, "pr-created", url)
     );
     confirmMock.mockImplementation(() => Promise.resolve(true));
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
-    );
 
-    try {
-      await main([tempDir], prUpdate);
+    await main([tempDir], prUpdate);
 
-      expect(noteMock).toHaveBeenCalled();
-      expect(confirmMock).toHaveBeenCalled();
-      expect(spawnSpy).toHaveBeenCalled();
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    expect(noteMock).toHaveBeenCalled();
+    expect(confirmMock).toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalled();
   });
 
   test("does not open browser when declined", async () => {
@@ -332,18 +355,11 @@ describe("main", () => {
       okResult(opts.repo, "pr-created", url)
     );
     confirmMock.mockImplementation(() => Promise.resolve(false));
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
-    );
 
-    try {
-      await main([tempDir], prUpdate);
+    await main([tempDir], prUpdate);
 
-      expect(noteMock).toHaveBeenCalled();
-      expect(spawnSpy).not.toHaveBeenCalled();
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    expect(noteMock).toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   test("exits when user cancels PR confirmation", async () => {
@@ -365,117 +381,78 @@ describe("main", () => {
   });
 
   test("openURLs uses osascript on darwin when browser not detected", async () => {
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
-    );
     const noopExec = mock(() =>
       Promise.resolve({ stdout: "", stderr: "", exitCode: 1 })
     );
 
-    try {
-      await openURLs(["https://example.com/2"], "darwin", noopExec);
-      expect(spawnSpy).toHaveBeenCalledTimes(1);
-      expect(spawnSpy).toHaveBeenLastCalledWith(
-        ["osascript", "-e", 'open location "https://example.com/2"'],
-        {
-          stdout: "ignore",
-          stderr: "ignore",
-          windowsHide: true,
-        }
-      );
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    await openURLs(["https://example.com/2"], "darwin", noopExec);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      "osascript",
+      ["-e", 'open location "https://example.com/2"'],
+      { stdio: "ignore", windowsHide: true }
+    );
   });
 
   test("openURLs falls back to cmd start on win32 when browser not detected", async () => {
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
-    );
     const noopExec = mock(() =>
       Promise.resolve({ stdout: "", stderr: "", exitCode: 1 })
     );
 
-    try {
-      await openURLs(["https://example.com/1"], "win32", noopExec);
-      expect(spawnSpy).toHaveBeenLastCalledWith(
-        ["cmd", "/c", "start", "", "https://example.com/1"],
-        {
-          stdout: "ignore",
-          stderr: "ignore",
-          windowsHide: true,
-        }
-      );
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    await openURLs(["https://example.com/1"], "win32", noopExec);
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      "cmd",
+      ["/c", "start", "", "https://example.com/1"],
+      { stdio: "ignore", windowsHide: true }
+    );
   });
 
   test("openURLs batches URLs via osascript on darwin without detected browser", async () => {
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
-    );
     const noopExec = mock(() =>
       Promise.resolve({ stdout: "", stderr: "", exitCode: 1 })
     );
 
-    try {
-      await openURLs(
-        ["https://example.com/1", "https://example.com/2"],
-        "darwin",
-        noopExec
-      );
-      expect(spawnSpy).toHaveBeenCalledTimes(1);
-      expect(spawnSpy).toHaveBeenLastCalledWith(
-        [
-          "osascript",
-          "-e",
-          'open location "https://example.com/1"\nopen location "https://example.com/2"',
-        ],
-        {
-          stdout: "ignore",
-          stderr: "ignore",
-          windowsHide: true,
-        }
-      );
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    await openURLs(
+      ["https://example.com/1", "https://example.com/2"],
+      "darwin",
+      noopExec
+    );
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      "osascript",
+      [
+        "-e",
+        'open location "https://example.com/1"\nopen location "https://example.com/2"',
+      ],
+      { stdio: "ignore", windowsHide: true }
+    );
   });
 
   test("openURLs uses cmd start for all URLs on win32", async () => {
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
-    );
     const noopExec = mock(() =>
       Promise.resolve({ stdout: "", stderr: "", exitCode: 1 })
     );
 
-    try {
-      await openURLs(
-        ["https://example.com/1", "https://example.com/2"],
-        "win32",
-        noopExec
-      );
-      expect(spawnSpy).toHaveBeenNthCalledWith(
-        1,
-        ["cmd", "/c", "start", "", "https://example.com/1"],
-        { stdout: "ignore", stderr: "ignore", windowsHide: true }
-      );
-      expect(spawnSpy).toHaveBeenNthCalledWith(
-        2,
-        ["cmd", "/c", "start", "", "https://example.com/2"],
-        { stdout: "ignore", stderr: "ignore", windowsHide: true }
-      );
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    await openURLs(
+      ["https://example.com/1", "https://example.com/2"],
+      "win32",
+      noopExec
+    );
+    expect(spawnMock).toHaveBeenNthCalledWith(
+      1,
+      "cmd",
+      ["/c", "start", "", "https://example.com/1"],
+      { stdio: "ignore", windowsHide: true }
+    );
+    expect(spawnMock).toHaveBeenNthCalledWith(
+      2,
+      "cmd",
+      ["/c", "start", "", "https://example.com/2"],
+      { stdio: "ignore", windowsHide: true }
+    );
   });
 
   test("openURLs batches all URLs in single command on win32 with detected browser", async () => {
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
-    );
     const mockExec = mock((cmd: string[]) => {
       if (cmd[0] === "powershell") {
         return Promise.resolve({
@@ -495,31 +472,20 @@ describe("main", () => {
       return Promise.resolve({ stdout: "", stderr: "", exitCode: 1 });
     });
 
-    try {
-      await openURLs(
-        ["https://example.com/1", "https://example.com/2"],
-        "win32",
-        mockExec
-      );
-      expect(spawnSpy).toHaveBeenCalledTimes(1);
-      expect(spawnSpy).toHaveBeenLastCalledWith(
-        [
-          "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
-          "--new-window",
-          "https://example.com/1",
-          "https://example.com/2",
-        ],
-        { stdout: "ignore", stderr: "ignore", windowsHide: true }
-      );
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    await openURLs(
+      ["https://example.com/1", "https://example.com/2"],
+      "win32",
+      mockExec
+    );
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
+      ["--new-window", "https://example.com/1", "https://example.com/2"],
+      { stdio: "ignore", windowsHide: true }
+    );
   });
 
   test("openURLs batches all URLs in single command on linux with detected browser", async () => {
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
-    );
     const mockExec = mock(() =>
       Promise.resolve({
         stdout: "google-chrome.desktop\n",
@@ -528,35 +494,20 @@ describe("main", () => {
       })
     );
 
-    try {
-      await openURLs(
-        ["https://example.com/1", "https://example.com/2"],
-        "linux",
-        mockExec
-      );
-      expect(spawnSpy).toHaveBeenCalledTimes(1);
-      expect(spawnSpy).toHaveBeenLastCalledWith(
-        [
-          "google-chrome",
-          "--new-window",
-          "https://example.com/1",
-          "https://example.com/2",
-        ],
-        {
-          stdout: "ignore",
-          stderr: "ignore",
-          windowsHide: true,
-        }
-      );
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    await openURLs(
+      ["https://example.com/1", "https://example.com/2"],
+      "linux",
+      mockExec
+    );
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      "google-chrome",
+      ["--new-window", "https://example.com/1", "https://example.com/2"],
+      { stdio: "ignore", windowsHide: true }
+    );
   });
 
   test("openURLs uses detected browser with --new-window on linux", async () => {
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
-    );
     const mockExec = mock(() =>
       Promise.resolve({
         stdout: "firefox.desktop\n",
@@ -565,69 +516,40 @@ describe("main", () => {
       })
     );
 
-    try {
-      await openURLs(["https://example.com/3"], "linux", mockExec);
-      expect(spawnSpy).toHaveBeenLastCalledWith(
-        ["firefox", "--new-window", "https://example.com/3"],
-        {
-          stdout: "ignore",
-          stderr: "ignore",
-          windowsHide: true,
-        }
-      );
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    await openURLs(["https://example.com/3"], "linux", mockExec);
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      "firefox",
+      ["--new-window", "https://example.com/3"],
+      { stdio: "ignore", windowsHide: true }
+    );
   });
 
   test("openURLs falls back to xdg-open on linux when detection fails", async () => {
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
-    );
     const failExec = mock(() =>
       Promise.resolve({ stdout: "", stderr: "", exitCode: 1 })
     );
 
-    try {
-      await openURLs(["https://example.com/3"], "linux", failExec);
-      expect(spawnSpy).toHaveBeenLastCalledWith(
-        ["xdg-open", "https://example.com/3"],
-        {
-          stdout: "ignore",
-          stderr: "ignore",
-          windowsHide: true,
-        }
-      );
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    await openURLs(["https://example.com/3"], "linux", failExec);
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      "xdg-open",
+      ["https://example.com/3"],
+      { stdio: "ignore", windowsHide: true }
+    );
   });
 
   test("openURLs uses browser override when provided on win32", async () => {
-    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue(
-      {} as ReturnType<typeof Bun.spawn>
+    await openURLs(
+      ["https://example.com/1", "https://example.com/2"],
+      "win32",
+      undefined,
+      "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe"
     );
-
-    try {
-      await openURLs(
-        ["https://example.com/1", "https://example.com/2"],
-        "win32",
-        undefined,
-        "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe"
-      );
-      expect(spawnSpy).toHaveBeenCalledTimes(1);
-      expect(spawnSpy).toHaveBeenLastCalledWith(
-        [
-          "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
-          "--new-window",
-          "https://example.com/1",
-          "https://example.com/2",
-        ],
-        { stdout: "ignore", stderr: "ignore", windowsHide: true }
-      );
-    } finally {
-      spawnSpy.mockRestore();
-    }
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
+      ["--new-window", "https://example.com/1", "https://example.com/2"],
+      { stdio: "ignore", windowsHide: true }
+    );
   });
 
   test("does not display PRs when list is empty", async () => {
@@ -656,14 +578,11 @@ describe("main", () => {
   });
 
   test("openURLNodejs uses child_process spawn", async () => {
-    // Use cross-platform command that exists
-    const testCmd =
-      process.platform === "win32"
-        ? ["cmd", "/c", "echo", "test"]
-        : ["echo", "test"];
-
-    await openURLNodejs(testCmd);
-    // If it succeeds, that's fine
+    await openURLNodejs(["echo", "test"]);
+    expect(spawnMock).toHaveBeenCalledWith("echo", ["test"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
   });
 
   test("openURLs handles empty URL list without calling detectBrowser", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,12 +13,29 @@ import { main } from "./index.ts";
 // windowsHide, so spawning cmd.exe for URL opening creates a visible console
 // window and triggers UAC prompts. Re-exec immediately under Node.js instead.
 if (typeof globalThis.Bun !== "undefined" && process.platform === "win32") {
-  const { exitCode } = Bun.spawnSync(["node", ...process.argv.slice(1)], {
-    stdin: "inherit",
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  process.exit(exitCode ?? 1);
+  try {
+    const { exitCode } = Bun.spawnSync(["node", ...process.argv.slice(1)], {
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    // exitCode is null when the process was killed by a signal; treat as failure.
+    process.exit(exitCode ?? 1);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ERR_ENOENT") {
+      process.stderr.write(
+        "repo-updater: could not find 'node' on PATH.\n" +
+          "Install Node.js (https://nodejs.org) or reinstall this CLI with " +
+          "'npm i -g repo-updater'.\n"
+      );
+    } else {
+      process.stderr.write(
+        `repo-updater: failed to re-exec under Node.js: ${String(err)}\n`
+      );
+    }
+    process.exit(1);
+  }
 }
 
 main().catch((err) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,19 @@
  */
 import { main } from "./index.ts";
 
+// `bun add -g` ignores the #!/usr/bin/env node shebang and runs this file
+// under Bun's runtime. On Windows, Bun's node:child_process does not honour
+// windowsHide, so spawning cmd.exe for URL opening creates a visible console
+// window and triggers UAC prompts. Re-exec immediately under Node.js instead.
+if (typeof globalThis.Bun !== "undefined" && process.platform === "win32") {
+  const { exitCode } = Bun.spawnSync(["node", ...process.argv.slice(1)], {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  process.exit(exitCode ?? 1);
+}
+
 main().catch((err) => {
   if (err instanceof Error) {
     console.error("Error:", err.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -612,11 +612,7 @@ export async function openURLs(
   const commands = buildOpenCommands(urls, platform, browserInfo);
 
   for (const cmd of commands) {
-    if (typeof Bun === "undefined") {
-      openURLNodejs(cmd);
-    } else {
-      openURLBun(cmd);
-    }
+    await openURLNodejs(cmd);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,15 +278,16 @@ export function openURLBunSync(cmd: string[]): number | null {
 }
 
 /**
- * Opens a URL using Node.js `child_process.spawn` with `detached: true`
- * and `stdio: "ignore"`.
+ * Opens a URL using Node.js `child_process.spawn` with `stdio: "ignore"`.
  *
  * @param cmd - The browser command and arguments.
  */
 export async function openURLNodejs(cmd: string[]): Promise<void> {
   const { spawn } = await import("node:child_process");
+  // Do NOT use detached: true — DETACHED_PROCESS causes CREATE_NO_WINDOW
+  // (windowsHide) to be ignored on Windows, letting cmd.exe allocate a new
+  // console window and making ShellExecuteEx appear suspicious (UAC prompt).
   const child = spawn(cmd[0], cmd.slice(1), {
-    detached: true,
     stdio: "ignore",
     windowsHide: true,
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -611,6 +611,11 @@ export async function openURLs(
     : await detectBrowser(platform, execFn);
   const commands = buildOpenCommands(urls, platform, browserInfo);
 
+  // Always route through openURLNodejs regardless of runtime. On Windows,
+  // Bun's node:child_process ignores windowsHide and triggers UAC prompts,
+  // so cli.ts re-execs under Node.js and all spawns must stay on the Node
+  // path. The POSIX perf impact of skipping the Bun spawn path is negligible.
+  // Do not revert this to a conditional branch between Bun and Node spawn.
   for (const cmd of commands) {
     await openURLNodejs(cmd);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,7 +265,11 @@ export function openURLBun(cmd: string[]): void {
  */
 export function openURLBunSync(cmd: string[]): number | null {
   try {
-    const proc = Bun.spawnSync(cmd, { stdout: "ignore", stderr: "ignore", windowsHide: true });
+    const proc = Bun.spawnSync(cmd, {
+      stdout: "ignore",
+      stderr: "ignore",
+      windowsHide: true,
+    });
     return proc.exitCode;
   } catch (err) {
     console.error(`openURLBunSync failed for ${cmd.join(" ")}:`, err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,7 +255,7 @@ async function handlePRDisplay(prUrls: string[]) {
  * @param cmd - The browser command and arguments.
  */
 export function openURLBun(cmd: string[]): void {
-  Bun.spawn(cmd, { stdout: "ignore", stderr: "ignore" });
+  Bun.spawn(cmd, { stdout: "ignore", stderr: "ignore", windowsHide: true });
 }
 
 /**
@@ -265,7 +265,7 @@ export function openURLBun(cmd: string[]): void {
  */
 export function openURLBunSync(cmd: string[]): number | null {
   try {
-    const proc = Bun.spawnSync(cmd, { stdout: "ignore", stderr: "ignore" });
+    const proc = Bun.spawnSync(cmd, { stdout: "ignore", stderr: "ignore", windowsHide: true });
     return proc.exitCode;
   } catch (err) {
     console.error(`openURLBunSync failed for ${cmd.join(" ")}:`, err);
@@ -284,6 +284,7 @@ export async function openURLNodejs(cmd: string[]): Promise<void> {
   const child = spawn(cmd[0], cmd.slice(1), {
     detached: true,
     stdio: "ignore",
+    windowsHide: true,
   });
   child.unref();
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -224,6 +224,7 @@ export async function execBun(
     cwd,
     stdout: "pipe",
     stderr: "pipe",
+    windowsHide: true,
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([
@@ -256,6 +257,7 @@ export async function execNodejs(
   const childProcess = spawn(cmd[0], cmd.slice(1), {
     cwd,
     stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
   });
 
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary

- Add `windowsHide: true` to `openURLBun`, `openURLBunSync`, and `openURLNodejs` so the `cmd /c start` fallback no longer flashes a new terminal window on Windows when opening PR URLs
- `src/cli.ts` shebang is already `#!/usr/bin/env node`; next build will emit the correct shebang in `dist/cli.mjs` so npm's Windows `.cmd` wrapper calls `node.exe` instead of `bun.exe` (fixes UAC triggered by bun's auto-update/symlink creation on Windows)

## Test plan

- [ ] Install package globally on Windows and run `repo-updater`
- [ ] Verify no new terminal window appears during URL opening
- [ ] Verify no UAC prompt appears on startup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Windows console flashes when opening URLs and removes UAC prompts on Windows startup. All URL opens now use Node’s `child_process.spawn` with `windowsHide`, and the CLI re-execs under Node when invoked via Bun on Windows.

- **Bug Fixes**
  - Route `openURLs` through `openURLNodejs` with `stdio: "ignore"` and `windowsHide: true`; tests updated to mock `node:child_process.spawn` and assert new args.
  - Set `windowsHide: true` on all spawns: `openURLBun`, `openURLBunSync`, `execBun`, and `execNodejs`.
  - Remove `detached: true` from `openURLNodejs` so `windowsHide` works and avoids console flashes/UAC on Windows.
  - On Windows under Bun, `src/cli.ts` re-execs with `node` and exits with the child code; adds ENOENT guard with a clear message if `node` isn’t on PATH and handles null `exitCode` from signal-killed processes.

- **Refactors**
  - Add inline comment explaining why `openURLs` always uses `openURLNodejs` and a changeset documenting the Windows re-exec diagnostics.

<sup>Written for commit e78dd94b0c710c4ebe9454ac9405a656c3848273. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide Windows console window when opening URLs and fix UAC prompt from Bun shebang
> - All URL-opening commands in [src/index.ts](https://github.com/mynameistito/repo-updater/pull/111/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) now route through `openURLNodejs` (Node.js `child_process.spawn`) regardless of runtime, avoiding UAC prompts triggered by Bun on Windows. `detached: true` is removed from `openURLNodejs`.
> - Adds `windowsHide: true` to all `Bun.spawn`, `Bun.spawnSync`, and `child_process.spawn` calls across URL opening and command execution in [src/runner.ts](https://github.com/mynameistito/repo-updater/pull/111/files#diff-d64beacb5711e9646c8e8e25cf23f283358d86c7f5f50b6f3aaf18044e356942).
> - Adds a Windows-only guard in [src/cli.ts](https://github.com/mynameistito/repo-updater/pull/111/files#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cdd) that re-execs the process under Node.js when invoked via Bun, with actionable ENOENT diagnostics if Node.js is not found.
> - Behavioral Change: on Windows with Bun, `openURLs` no longer uses Bun's spawn; CLI entry now always delegates to Node.js on Windows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e78dd94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->