### PR TITLE
Add browser config opening smoke test

### DIFF
--- a/.changeset/brave-browsers-open.md
+++ b/.changeset/brave-browsers-open.md
@@ -1,0 +1,5 @@
+---
+"repo-updater": patch
+---
+
+Add regression coverage and an opt-in local smoke test for opening PR URLs with a configured browser.

--- a/__tests__/browser-open.local.test.ts
+++ b/__tests__/browser-open.local.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { loadConfig } from "../src/config.ts";
+
+const RUN_ENV = "REPO_UPDATER_OPEN_BROWSER_TEST";
+const BROWSER_ENV = "REPO_UPDATER_BROWSER";
+const URL_ENV = "REPO_UPDATER_OPEN_BROWSER_URL";
+const DEFAULT_URL = "https://example.com/?repo-updater-browser-test=1";
+const LAUNCH_TIMEOUT_MS = 5000;
+const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes"]);
+const WINDOWS_ABSOLUTE_PATH_REGEX = /^[A-Z]:\\/i;
+
+const shouldRun = TRUTHY_ENV_VALUES.has(
+  (process.env[RUN_ENV] ?? "").toLowerCase()
+);
+
+function getBrowserOverride(): string {
+  const envBrowser = process.env[BROWSER_ENV];
+  if (envBrowser) {
+    return envBrowser;
+  }
+
+  const config = loadConfig();
+  if (config.isErr()) {
+    throw new Error(
+      `Set ${BROWSER_ENV} or create a repo-updater config with a browser field before running this local test. ${config.error.message}`
+    );
+  }
+
+  if (!config.value.browser) {
+    throw new Error(
+      `Set ${BROWSER_ENV} or add a browser field to your repo-updater config before running this local test.`
+    );
+  }
+
+  return config.value.browser;
+}
+
+function isFilesystemPath(value: string): boolean {
+  return (
+    WINDOWS_ABSOLUTE_PATH_REGEX.test(value) ||
+    value.includes("/") ||
+    value.includes("\\")
+  );
+}
+
+function buildLocalOpenCommand(
+  browser: string,
+  url: string
+): { args: string[]; cmd: string; waitForExit: boolean } {
+  if (process.platform === "win32") {
+    return {
+      cmd: "cmd",
+      args: ["/c", "start", "", browser, "--new-window", url],
+      waitForExit: true,
+    };
+  }
+
+  if (process.platform === "darwin" && !isFilesystemPath(browser)) {
+    return {
+      cmd: "open",
+      args: ["-na", browser, "--args", "--new-window", url],
+      waitForExit: true,
+    };
+  }
+
+  return { cmd: browser, args: ["--new-window", url], waitForExit: false };
+}
+
+async function openBrowserForLocalTest(browser: string, url: string) {
+  const command = buildLocalOpenCommand(browser, url);
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command.cmd, command.args, {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    let settled = false;
+
+    const settle = (error?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      if (!command.waitForExit) {
+        child.unref();
+      }
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      settle(
+        new Error(
+          `Timed out launching browser command: ${command.cmd} ${command.args.join(" ")}`
+        )
+      );
+    }, LAUNCH_TIMEOUT_MS);
+
+    child.once("error", (error) => {
+      settle(error);
+    });
+
+    if (command.waitForExit) {
+      child.once("close", (code) => {
+        if (code === 0) {
+          settle();
+        } else {
+          settle(
+            new Error(
+              `Browser launch command failed with exit code ${code}: ${command.cmd} ${command.args.join(" ")}`
+            )
+          );
+        }
+      });
+    } else {
+      child.once("spawn", () => {
+        setTimeout(settle, 500);
+      });
+    }
+  });
+}
+
+describe("local browser opening", () => {
+  test.skipIf(!shouldRun)(
+    `opens a real browser window when ${RUN_ENV}=1`,
+    async () => {
+      const browser = getBrowserOverride();
+      const url = process.env[URL_ENV] ?? DEFAULT_URL;
+
+      if (isFilesystemPath(browser) && !existsSync(browser)) {
+        throw new Error(
+          `Configured browser executable does not exist: ${browser}`
+        );
+      }
+
+      await openBrowserForLocalTest(browser, url);
+
+      expect(browser.length).toBeGreaterThan(0);
+    }
+  );
+});

--- a/__tests__/browser-open.local.test.ts
+++ b/__tests__/browser-open.local.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { extname, isAbsolute } from "node:path";
 import { loadConfig } from "../src/config.ts";
 
 const RUN_ENV = "REPO_UPDATER_OPEN_BROWSER_TEST";
@@ -10,6 +11,7 @@ const DEFAULT_URL = "https://example.com/?repo-updater-browser-test=1";
 const LAUNCH_TIMEOUT_MS = 5000;
 const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes"]);
 const WINDOWS_ABSOLUTE_PATH_REGEX = /^[A-Z]:\\/i;
+const ALLOWED_URL_PROTOCOLS = new Set(["http:", "https:"]);
 
 const shouldRun = TRUTHY_ENV_VALUES.has(
   (process.env[RUN_ENV] ?? "").toLowerCase()
@@ -37,6 +39,19 @@ function getBrowserOverride(): string {
   return config.value.browser;
 }
 
+function getTestUrl(): string {
+  const rawUrl = process.env[URL_ENV] ?? DEFAULT_URL;
+  const url = new URL(rawUrl);
+
+  if (!ALLOWED_URL_PROTOCOLS.has(url.protocol)) {
+    throw new Error(
+      `${URL_ENV} must use an http: or https: URL, received: ${rawUrl}`
+    );
+  }
+
+  return url.href;
+}
+
 function isFilesystemPath(value: string): boolean {
   return (
     WINDOWS_ABSOLUTE_PATH_REGEX.test(value) ||
@@ -45,34 +60,39 @@ function isFilesystemPath(value: string): boolean {
   );
 }
 
-function buildLocalOpenCommand(
-  browser: string,
-  url: string
-): { args: string[]; cmd: string; waitForExit: boolean } {
-  if (process.platform === "win32") {
-    return {
-      cmd: "cmd",
-      args: ["/c", "start", "", browser, "--new-window", url],
-      waitForExit: true,
-    };
+function validateBrowserExecutable(browser: string): string {
+  if (!browser) {
+    throw new Error(`${BROWSER_ENV} or config browser must not be empty.`);
   }
 
-  if (process.platform === "darwin" && !isFilesystemPath(browser)) {
-    return {
-      cmd: "open",
-      args: ["-na", browser, "--args", "--new-window", url],
-      waitForExit: true,
-    };
+  if (!(isFilesystemPath(browser) && isAbsolute(browser))) {
+    throw new Error(
+      `${BROWSER_ENV} or config browser must be an absolute executable path for this local smoke test.`
+    );
   }
 
-  return { cmd: browser, args: ["--new-window", url], waitForExit: false };
+  if (!existsSync(browser)) {
+    throw new Error(`Configured browser executable does not exist: ${browser}`);
+  }
+
+  if (
+    process.platform === "win32" &&
+    extname(browser).toLowerCase() !== ".exe"
+  ) {
+    throw new Error(
+      `Configured Windows browser must be a .exe file: ${browser}`
+    );
+  }
+
+  return browser;
 }
 
 async function openBrowserForLocalTest(browser: string, url: string) {
-  const command = buildLocalOpenCommand(browser, url);
+  const browserExecutable = validateBrowserExecutable(browser);
+  const browserArgs = ["--new-window", url];
 
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(command.cmd, command.args, {
+    const child = spawn(browserExecutable, browserArgs, {
       stdio: "ignore",
       windowsHide: true,
     });
@@ -84,9 +104,7 @@ async function openBrowserForLocalTest(browser: string, url: string) {
       }
       settled = true;
       clearTimeout(timeout);
-      if (!command.waitForExit) {
-        child.unref();
-      }
+      child.unref();
       if (error) {
         reject(error);
       } else {
@@ -97,7 +115,7 @@ async function openBrowserForLocalTest(browser: string, url: string) {
     const timeout = setTimeout(() => {
       settle(
         new Error(
-          `Timed out launching browser command: ${command.cmd} ${command.args.join(" ")}`
+          `Timed out launching browser command: ${browserExecutable} ${browserArgs.join(" ")}`
         )
       );
     }, LAUNCH_TIMEOUT_MS);
@@ -106,23 +124,19 @@ async function openBrowserForLocalTest(browser: string, url: string) {
       settle(error);
     });
 
-    if (command.waitForExit) {
-      child.once("close", (code) => {
-        if (code === 0) {
-          settle();
-        } else {
-          settle(
-            new Error(
-              `Browser launch command failed with exit code ${code}: ${command.cmd} ${command.args.join(" ")}`
-            )
-          );
-        }
-      });
-    } else {
-      child.once("spawn", () => {
-        setTimeout(settle, 500);
-      });
-    }
+    child.once("spawn", () => {
+      setTimeout(settle, 500);
+    });
+
+    child.once("close", (code) => {
+      if (code && !settled) {
+        settle(
+          new Error(
+            `Browser launch command exited early with code ${code}: ${browserExecutable} ${browserArgs.join(" ")}`
+          )
+        );
+      }
+    });
   });
 }
 
@@ -131,13 +145,7 @@ describe("local browser opening", () => {
     `opens a real browser window when ${RUN_ENV}=1`,
     async () => {
       const browser = getBrowserOverride();
-      const url = process.env[URL_ENV] ?? DEFAULT_URL;
-
-      if (isFilesystemPath(browser) && !existsSync(browser)) {
-        throw new Error(
-          `Configured browser executable does not exist: ${browser}`
-        );
-      }
+      const url = getTestUrl();
 
       await openBrowserForLocalTest(browser, url);
 

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -9,6 +9,7 @@ import {
   test,
 } from "bun:test";
 import { spawn as realSpawn } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -63,7 +64,10 @@ const capturedSpawn = realSpawn;
 const spawnMock = mock(
   (cmd: string, args: string[], opts?: Parameters<typeof realSpawn>[2]) => {
     if (opts && "stdio" in opts && opts.stdio === "ignore") {
-      return { unref: mock(noop) } as unknown as ReturnType<typeof realSpawn>;
+      const child = new EventEmitter() as EventEmitter & { unref: () => void };
+      child.unref = mock(noop);
+      queueMicrotask(() => child.emit("spawn"));
+      return child as unknown as ReturnType<typeof realSpawn>;
     }
     return capturedSpawn(cmd, args, opts as Parameters<typeof realSpawn>[2]);
   }

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -349,6 +349,27 @@ describe("main", () => {
     expect(spawnMock).toHaveBeenCalled();
   });
 
+  test("uses browser from config file when opening PR URLs", async () => {
+    const url = "https://github.com/owner/repo/pull/1";
+    const browser =
+      "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe";
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(configPath, JSON.stringify({ repos: [tempDir], browser }));
+    const prUpdate = mock((opts: { repo: string }) =>
+      okResult(opts.repo, "pr-created", url)
+    );
+    confirmMock.mockImplementation(() => Promise.resolve(true));
+
+    await main(["--config", configPath], prUpdate);
+
+    expect(logMock.info).toHaveBeenCalledWith(`Using browser: ${browser}`);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenLastCalledWith(browser, ["--new-window", url], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  });
+
   test("does not open browser when declined", async () => {
     const url = "https://github.com/owner/repo/pull/1";
     const prUpdate = mock((opts: { repo: string }) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,7 +291,48 @@ export async function openURLNodejs(cmd: string[]): Promise<void> {
     stdio: "ignore",
     windowsHide: true,
   });
-  child.unref();
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const settle = (error?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      child.unref();
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      settle(
+        new Error(`Timed out launching browser command: ${cmd.join(" ")}`)
+      );
+    }, OPEN_URL_SPAWN_TIMEOUT_MS);
+
+    child.once("error", (error) => {
+      settle(error);
+    });
+
+    child.once("spawn", () => {
+      setTimeout(settle, OPEN_URL_SPAWN_GRACE_MS);
+    });
+
+    child.once("close", (code) => {
+      if (code && !settled) {
+        settle(
+          new Error(
+            `Browser launch command exited early with code ${code}: ${cmd.join(" ")}`
+          )
+        );
+      }
+    });
+  });
 }
 
 /**
@@ -317,6 +358,10 @@ const MACOS_FIREFOX_REGEX =
 const REG_COMMAND_REGEX = /\(Default\)\s+REG_SZ\s+"?([^"]+\.exe)"?/i;
 /** Matches `.exe` file extension in a Windows path. */
 const EXE_SUFFIX_REGEX = /\.exe$/i;
+/** Maximum time to wait for a browser process to report successful spawn. */
+const OPEN_URL_SPAWN_TIMEOUT_MS = 5000;
+/** Small grace period after spawn so Windows has time to hand off the URL. */
+const OPEN_URL_SPAWN_GRACE_MS = 500;
 
 /** Maps Windows HTTP handler prog IDs to browser executable names. */
 const windowsProgIdMap: Record<string, string> = {


### PR DESCRIPTION
## Summary
- add regression coverage that verifies config-file browser overrides are passed to PR URL opening
- add an opt-in local smoke test for launching the configured browser
- add a patch changeset for the next release

## Testing
- bun test
- bun run test:node
- bun run check
- bun run typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests to ensure PR URLs open with the configured browser, plus an opt-in local smoke test that launches a real browser without using a shell. Also waits for the browser to spawn before exiting to reduce flakiness, and includes a patch changeset for `repo-updater`.

<sup>Written for commit 1bb234adc3aa5ced10bee89637fb65fde6194c5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add smoke test and error handling for browser-open in `openURLNodejs`
> - Replaces the fire-and-forget `spawn` in [`openURLNodejs`](https://github.com/mynameistito/repo-updater/pull/128/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) with a promise that waits for the child process to emit `spawn`, rejects on error/timeout/non-zero exit, and unrefs after settling.
> - Adds a new integration test in [`__tests__/cli.test.ts`](https://github.com/mynameistito/repo-updater/pull/128/files#diff-a9e688695c9600111a2ec493711ad781544005025f82eb0d2801c1f94f06508c) that verifies spawn is called with the configured browser, `--new-window`, the PR URL, and correct stdio options.
> - Adds an opt-in local smoke test in [`__tests__/browser-open.local.test.ts`](https://github.com/mynameistito/repo-updater/pull/128/files#diff-6baca628509473869de67ea719e4d4fbeaf7b0e993f6f1ea0f3e656ab5283351) that opens a real browser window when `REPO_UPDATER_OPEN_BROWSER_TEST` is set.
> - Behavioral Change: callers awaiting `openURLNodejs` now block for up to 5.5 seconds and will receive a rejected promise if the browser fails to spawn, instead of silently ignoring errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bb234a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->