### PR TITLE
fix: suppress Windows UAC prompt and startup terminal flash

### DIFF
--- a/.changeset/fix-windows-uac-and-terminal-flash.md
+++ b/.changeset/fix-windows-uac-and-terminal-flash.md
@@ -1,0 +1,8 @@
+---
+"repo-updater": minor
+---
+
+Fix Windows UAC prompt and terminal-window flash on startup.
+
+- Drop the `Bun.spawnSync(["node", ...])` re-exec in `cli.ts`. It was added to work around `windowsHide` being ignored in Bun's `node:child_process`, but on Windows the re-exec spawned `node` (often a `.cmd` shim under nvm/fnm/volta) through Bun's spawn, which flashed a console window and added an extra elevation hop.
+- Add a `postinstall` script (`scripts/install-windows-manifest.mjs`) that writes an external `repo-updater.exe.manifest` declaring `asInvoker` next to the shim. This suppresses Windows' Installer Detection heuristic, which auto-elevates unsigned `.exe` files whose names contain `install`, `setup`, `update`, or `patch`. Runs automatically for npm/pnpm/yarn global installs; bun users need to either trust the package's lifecycle scripts or run the script manually (see README).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ For **Bun**, lifecycle scripts are skipped unless the package is trusted. Either
      </trustInfo>
    </assembly>
    '@ | Set-Content "$exe.manifest" -Encoding UTF8
+   # Bump exe mtime so Windows invalidates its cached elevation decision:
+   (Get-Item $exe).LastWriteTime = Get-Date
    ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -60,6 +60,37 @@ pnpm install repo-updater -g                                   # with pnpm
 deno install -g -n repo-updater jsr:@mynameistito/repo-updater/cli # with Deno
 ```
 
+### Windows: UAC prompt on launch
+
+Windows' Installer Detection heuristic auto-elevates unsigned `.exe` files whose name contains `install`, `setup`, `update`, or `patch`. The bin shim created by `bun add -g` matches `update` and triggers a UAC prompt at startup.
+
+The package's `postinstall` writes an external `repo-updater.exe.manifest` next to the shim (declaring `asInvoker`) which suppresses the prompt. This runs automatically for **npm / pnpm / yarn** global installs.
+
+For **Bun**, lifecycle scripts are skipped unless the package is trusted. Either:
+
+1. Install via npm/pnpm/yarn instead, **or**
+2. Run the suppression script manually after `bun add -g repo-updater`:
+
+   ```powershell
+   node (Join-Path (npm root -g) "repo-updater\scripts\install-windows-manifest.mjs")
+   ```
+
+   Or, if Node is not installed, drop the manifest with PowerShell directly:
+
+   ```powershell
+   $exe = (Get-Command repo-updater).Source
+   @'
+   <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+   <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+       <security><requestedPrivileges>
+         <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+       </requestedPrivileges></security>
+     </trustInfo>
+   </assembly>
+   '@ | Set-Content "$exe.manifest" -Encoding UTF8
+   ```
+
 ## Usage
 
 ```text

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "node": ">=22.6.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "scripts/install-windows-manifest.mjs"
   ],
   "scripts": {
     "typecheck": "tsgo --noEmit",
@@ -46,6 +47,7 @@
     "fix": "ultracite fix",
     "build": "tsdown",
     "sync:jsr": "bun scripts/sync-jsr-version.ts",
+    "postinstall": "node scripts/install-windows-manifest.mjs",
     "prepublishOnly": "bun run build && bun run typecheck",
     "version": "changeset version && bun run sync:jsr && bunx ultracite fix deno.json"
   },

--- a/scripts/install-windows-manifest.mjs
+++ b/scripts/install-windows-manifest.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * @module install-windows-manifest
+ *
+ * postinstall helper. On Windows, drops an external application manifest
+ * next to the `repo-updater.exe` shim to opt out of Windows Installer
+ * Detection (UAC auto-elevation triggered by the substring "update" in the
+ * unsigned shim filename). No-op on non-Windows platforms.
+ *
+ * Locates shims in known global install prefixes for npm, pnpm, yarn, bun.
+ * Failures are non-fatal: postinstall must never block the user's install.
+ */
+import { existsSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANIFEST = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity type="win32" name="repo-updater" version="1.0.0.0" processorArchitecture="*"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>
+`;
+
+if (process.platform !== "win32") {
+  process.exit(0);
+}
+
+const home = homedir();
+
+// Candidate locations for global bin shims across package managers.
+const candidates = [
+  process.env.npm_config_prefix
+    ? join(process.env.npm_config_prefix, "repo-updater.exe")
+    : null,
+  process.env.PNPM_HOME ? join(process.env.PNPM_HOME, "repo-updater.exe") : null,
+  process.env.BUN_INSTALL
+    ? join(process.env.BUN_INSTALL, "bin", "repo-updater.exe")
+    : null,
+  join(home, ".cache", ".bun", "bin", "repo-updater.exe"),
+  join(home, ".bun", "bin", "repo-updater.exe"),
+  join(home, "AppData", "Roaming", "npm", "repo-updater.exe"),
+  join(home, "AppData", "Local", "pnpm", "repo-updater.exe"),
+  join(home, "AppData", "Local", "Yarn", "bin", "repo-updater.exe"),
+].filter((p) => typeof p === "string");
+
+let written = 0;
+for (const exe of candidates) {
+  if (!existsSync(exe)) {
+    continue;
+  }
+  const manifestPath = `${exe}.manifest`;
+  try {
+    writeFileSync(manifestPath, MANIFEST, "utf8");
+    written += 1;
+    console.log(`repo-updater: wrote ${manifestPath} (UAC suppression)`);
+  } catch (err) {
+    console.warn(
+      `repo-updater: could not write ${manifestPath}: ${(err instanceof Error ? err.message : String(err))}`
+    );
+  }
+}
+
+if (written === 0) {
+  console.log(
+    "repo-updater: no .exe shim found to manifest. If you see a UAC prompt on launch, run this script again or install via npm."
+  );
+}

--- a/scripts/install-windows-manifest.mjs
+++ b/scripts/install-windows-manifest.mjs
@@ -47,7 +47,9 @@ const candidates = [
   process.env.npm_config_prefix
     ? join(process.env.npm_config_prefix, "repo-updater.exe")
     : null,
-  process.env.PNPM_HOME ? join(process.env.PNPM_HOME, "repo-updater.exe") : null,
+  process.env.PNPM_HOME
+    ? join(process.env.PNPM_HOME, "repo-updater.exe")
+    : null,
   process.env.BUN_INSTALL
     ? join(process.env.BUN_INSTALL, "bin", "repo-updater.exe")
     : null,
@@ -74,7 +76,7 @@ for (const exe of candidates) {
     console.log(`repo-updater: wrote ${manifestPath} (UAC suppression)`);
   } catch (err) {
     console.warn(
-      `repo-updater: could not write ${manifestPath}: ${(err instanceof Error ? err.message : String(err))}`
+      `repo-updater: could not write ${manifestPath}: ${err instanceof Error ? err.message : String(err)}`
     );
   }
 }

--- a/scripts/install-windows-manifest.mjs
+++ b/scripts/install-windows-manifest.mjs
@@ -10,7 +10,7 @@
  * Locates shims in known global install prefixes for npm, pnpm, yarn, bun.
  * Failures are non-fatal: postinstall must never block the user's install.
  */
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, utimesSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -66,6 +66,10 @@ for (const exe of candidates) {
   const manifestPath = `${exe}.manifest`;
   try {
     writeFileSync(manifestPath, MANIFEST, "utf8");
+    // Bump the exe's mtime so Windows invalidates its cached elevation
+    // decision and re-reads the external manifest on next launch.
+    const now = new Date();
+    utimesSync(exe, now, now);
     written += 1;
     console.log(`repo-updater: wrote ${manifestPath} (UAC suppression)`);
   } catch (err) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,36 +8,6 @@
  */
 import { main } from "./index.ts";
 
-// `bun add -g` ignores the #!/usr/bin/env node shebang and runs this file
-// under Bun's runtime. On Windows, Bun's node:child_process does not honour
-// windowsHide, so spawning cmd.exe for URL opening creates a visible console
-// window and triggers UAC prompts. Re-exec immediately under Node.js instead.
-if (typeof globalThis.Bun !== "undefined" && process.platform === "win32") {
-  try {
-    const { exitCode } = Bun.spawnSync(["node", ...process.argv.slice(1)], {
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-    // exitCode is null when the process was killed by a signal; treat as failure.
-    process.exit(exitCode ?? 1);
-  } catch (err: unknown) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT" || code === "ERR_ENOENT") {
-      process.stderr.write(
-        "repo-updater: could not find 'node' on PATH.\n" +
-          "Install Node.js (https://nodejs.org) or reinstall this CLI with " +
-          "'npm i -g repo-updater'.\n"
-      );
-    } else {
-      process.stderr.write(
-        `repo-updater: failed to re-exec under Node.js: ${String(err)}\n`
-      );
-    }
-    process.exit(1);
-  }
-}
-
 main().catch((err) => {
   if (err instanceof Error) {
     console.error("Error:", err.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -656,11 +656,11 @@ export async function openURLs(
     : await detectBrowser(platform, execFn);
   const commands = buildOpenCommands(urls, platform, browserInfo);
 
-  // Always route through openURLNodejs regardless of runtime. On Windows,
-  // Bun's node:child_process ignores windowsHide and triggers UAC prompts,
-  // so cli.ts re-execs under Node.js and all spawns must stay on the Node
-  // path. The POSIX perf impact of skipping the Bun spawn path is negligible.
-  // Do not revert this to a conditional branch between Bun and Node spawn.
+  // Route through openURLNodejs unconditionally. Under Bun, this still uses
+  // Bun's node:child_process implementation, which honours `windowsHide`
+  // when stdio is "ignore" so no console window flashes for browser launch.
+  // The Windows UAC prompt at startup is handled separately via the external
+  // application manifest written by scripts/install-windows-manifest.mjs.
   for (const cmd of commands) {
     await openURLNodejs(cmd);
   }


### PR DESCRIPTION
- Drop Bun-to-Node re-exec in cli.ts. The re-exec spawned `node` (often a .cmd shim under nvm/fnm/volta) through Bun.spawnSync, causing a console window to flash on every startup.
- Add postinstall script that writes an external `repo-updater.exe.manifest` next to the global bin shim with `asInvoker` execution level. This bypasses Windows Installer Detection, which auto-elevates unsigned `.exe` files whose names contain `install`, `setup`, `update`, or `patch`.
- Document bun-on-Windows caveat (lifecycle scripts skipped without trust) with manual fallback commands.

## What does this PR do?

<!-- A short summary of the change and why it was made. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / CI / tooling

## Related issue

<!-- Every PR must be linked to an issue. If one doesn't exist yet, open one first. -->

Closes #

## Checklist

- [ ] Tests added or updated
- [ ] `bun test` and `bun run test:node` pass
- [ ] `bun run typecheck` passes
- [ ] Changeset added (`bunx changeset`) — or this PR is non-user-facing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows UAC prompts and the brief terminal flash at CLI startup by removing the Bun-to-Node re-exec and adding an install-time Windows manifest.

- **Bug Fixes**
  - Removed the Bun→Node re-exec in `src/cli.ts` that caused a console window flash and an extra elevation hop.
  - Added `postinstall` script `scripts/install-windows-manifest.mjs` to write `repo-updater.exe.manifest` with `asInvoker` next to the global shim and touch the `.exe` mtime to invalidate Windows’ cached elevation decision. Runs on `npm`/`pnpm`/`yarn` installs.
  - Routed URL opening through the common Node-path helper unconditionally; under Bun this uses its `node:child_process` with `windowsHide`, avoiding visible console windows on Windows.

- **Migration**
  - `bun` global installs may skip lifecycle scripts unless the package is trusted. If you still see a UAC prompt, run the manifest script manually (see README).

<sup>Written for commit 1791421c77875a15c5f11d158dab427eb6cc0ef3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows UAC prompt and terminal flash by adding a postinstall manifest installer
> - Adds [scripts/install-windows-manifest.mjs](https://github.com/mynameistito/repo-updater/pull/132/files#diff-07dcdb1c0f78b011ee396b38b2388d3a5a38b9b73b57a930dfd3c3e1d25d2b5a), a postinstall script that writes a side-by-side application manifest next to `repo-updater.exe` shims for npm, pnpm, yarn, and bun, setting `requestedExecutionLevel` to `asInvoker` to suppress the UAC elevation prompt.
> - Removes the Bun-on-Windows re-exec block in [src/cli.ts](https://github.com/mynameistito/repo-updater/pull/132/files#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cdd) that spawned a `node` subprocess via `Bun.spawnSync`; the CLI now runs directly in the current process.
> - Documents manual manifest installation steps for Bun users in the README, since Bun does not run postinstall scripts.
> - Behavioral Change: the postinstall step runs `node scripts/install-windows-manifest.mjs` on every install; non-Windows installs exit immediately with no effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1791421.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->