### PR TITLE
fix: self-heal Windows UAC on first CLI invocation

### DIFF
--- a/.changeset/windows-uac-self-heal.md
+++ b/.changeset/windows-uac-self-heal.md
@@ -1,0 +1,11 @@
+---
+"repo-updater": patch
+---
+
+Self-heal Windows UAC suppression on first CLI invocation.
+
+`bun add -g` skips lifecycle scripts unconditionally, so the v0.7.7 postinstall couldn't drop the external `repo-updater.exe.manifest` for bun-installed users — they kept seeing the UAC prompt at startup.
+
+Fixed by extracting the manifest-writing logic into `src/windows-manifest.ts` and invoking `ensureWindowsManifest()` at the top of `cli.ts`. The shim's first launch under bun still triggers UAC (Windows evaluates the binary before any code runs), but the running process drops the manifest + bumps the shim's mtime to invalidate Windows' cached elevation decision. Every subsequent launch is silent.
+
+The postinstall script now delegates to the same module so npm/pnpm/yarn installs continue to be zero-touch.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
       "types": "./dist/cli.d.mts",
       "import": "./dist/cli.mjs"
     },
+    "./windows-manifest": "./dist/windows-manifest.mjs",
     "./package.json": "./package.json"
   }
 }

--- a/scripts/install-windows-manifest.mjs
+++ b/scripts/install-windows-manifest.mjs
@@ -10,9 +10,24 @@
  * runs zero-touch for npm/pnpm/yarn global installs. Bun globals self-heal
  * on first invocation via cli.ts (one UAC prompt, then silent).
  */
-import { ensureWindowsManifest } from "../dist/windows-manifest.mjs";
-
-const patched = ensureWindowsManifest();
+// Dynamic import: `dist/` is absent during local dev / from-source installs,
+// and postinstall must never fail. ERR_MODULE_NOT_FOUND => silent no-op.
+let patched = 0;
+try {
+  const mod = await import("../dist/windows-manifest.mjs");
+  patched = mod.ensureWindowsManifest();
+} catch (err) {
+  if (
+    !(
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      err.code === "ERR_MODULE_NOT_FOUND"
+    )
+  ) {
+    throw err;
+  }
+}
 if (patched > 0) {
   console.log(
     `repo-updater: wrote external manifest for ${patched} shim(s) (Windows UAC suppression)`

--- a/scripts/install-windows-manifest.mjs
+++ b/scripts/install-windows-manifest.mjs
@@ -2,87 +2,19 @@
 /**
  * @module install-windows-manifest
  *
- * postinstall helper. On Windows, drops an external application manifest
- * next to the `repo-updater.exe` shim to opt out of Windows Installer
- * Detection (UAC auto-elevation triggered by the substring "update" in the
- * unsigned shim filename). No-op on non-Windows platforms.
+ * postinstall thin wrapper. Delegates to the bundled `windows-manifest`
+ * module so the manifest payload and shim-discovery logic stay in one
+ * place (src/windows-manifest.ts). Safe no-op on non-Windows.
  *
- * Locates shims in known global install prefixes for npm, pnpm, yarn, bun.
- * Failures are non-fatal: postinstall must never block the user's install.
+ * Note: bun's `bun add -g` skips lifecycle scripts entirely, so this only
+ * runs zero-touch for npm/pnpm/yarn global installs. Bun globals self-heal
+ * on first invocation via cli.ts (one UAC prompt, then silent).
  */
-import { existsSync, utimesSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { ensureWindowsManifest } from "../dist/windows-manifest.mjs";
 
-const MANIFEST = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity type="win32" name="repo-updater" version="1.0.0.0" processorArchitecture="*"/>
-  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-    <security>
-      <requestedPrivileges>
-        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
-      </requestedPrivileges>
-    </security>
-  </trustInfo>
-  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-    <application>
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-    </application>
-  </compatibility>
-</assembly>
-`;
-
-if (process.platform !== "win32") {
-  process.exit(0);
-}
-
-const home = homedir();
-
-// Candidate locations for global bin shims across package managers.
-const candidates = [
-  process.env.npm_config_prefix
-    ? join(process.env.npm_config_prefix, "repo-updater.exe")
-    : null,
-  process.env.PNPM_HOME
-    ? join(process.env.PNPM_HOME, "repo-updater.exe")
-    : null,
-  process.env.BUN_INSTALL
-    ? join(process.env.BUN_INSTALL, "bin", "repo-updater.exe")
-    : null,
-  join(home, ".cache", ".bun", "bin", "repo-updater.exe"),
-  join(home, ".bun", "bin", "repo-updater.exe"),
-  join(home, "AppData", "Roaming", "npm", "repo-updater.exe"),
-  join(home, "AppData", "Local", "pnpm", "repo-updater.exe"),
-  join(home, "AppData", "Local", "Yarn", "bin", "repo-updater.exe"),
-].filter((p) => typeof p === "string");
-
-let written = 0;
-for (const exe of candidates) {
-  if (!existsSync(exe)) {
-    continue;
-  }
-  const manifestPath = `${exe}.manifest`;
-  try {
-    writeFileSync(manifestPath, MANIFEST, "utf8");
-    // Bump the exe's mtime so Windows invalidates its cached elevation
-    // decision and re-reads the external manifest on next launch.
-    const now = new Date();
-    utimesSync(exe, now, now);
-    written += 1;
-    console.log(`repo-updater: wrote ${manifestPath} (UAC suppression)`);
-  } catch (err) {
-    console.warn(
-      `repo-updater: could not write ${manifestPath}: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
-}
-
-if (written === 0) {
+const patched = ensureWindowsManifest();
+if (patched > 0) {
   console.log(
-    "repo-updater: no .exe shim found to manifest. If you see a UAC prompt on launch, run this script again or install via npm."
+    `repo-updater: wrote external manifest for ${patched} shim(s) (Windows UAC suppression)`
   );
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,13 @@
  * the process with code 1.
  */
 import { main } from "./index.ts";
+import { ensureWindowsManifest } from "./windows-manifest.ts";
+
+// Drop external asInvoker manifest next to the bun-generated `.exe` shim on
+// Windows so subsequent launches do not trigger UAC. First launch under bun
+// still UACs (the OS evaluates the binary before any code runs); from then on
+// it is silent. No-op on non-Windows. See windows-manifest.ts for context.
+ensureWindowsManifest();
 
 main().catch((err) => {
   if (err instanceof Error) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,13 +7,6 @@
  * the process with code 1.
  */
 import { main } from "./index.ts";
-import { ensureWindowsManifest } from "./windows-manifest.ts";
-
-// Drop external asInvoker manifest next to the bun-generated `.exe` shim on
-// Windows so subsequent launches do not trigger UAC. First launch under bun
-// still UACs (the OS evaluates the binary before any code runs); from then on
-// it is silent. No-op on non-Windows. See windows-manifest.ts for context.
-ensureWindowsManifest();
 
 main().catch((err) => {
   if (err instanceof Error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
   validateRepos,
 } from "./config.ts";
 import { execBun, execNodejs, updateRepo } from "./runner.ts";
+import { ensureWindowsManifest } from "./windows-manifest.ts";
 
 /**
  * Prints CLI usage information and available flags to standard output.
@@ -689,6 +690,12 @@ export async function main(
   argv?: string[],
   updateFn: typeof updateRepo = updateRepo
 ) {
+  // Drop external asInvoker manifest next to the bun-generated `.exe` shim on
+  // Windows so subsequent launches do not trigger UAC. First launch under bun
+  // still UACs (OS evaluates the binary before any user code runs); from then
+  // on it is silent. No-op on non-Windows. See windows-manifest.ts for context.
+  ensureWindowsManifest();
+
   const args = parseArgs(argv ?? process.argv.slice(2));
 
   if (args.help) {

--- a/src/windows-manifest.ts
+++ b/src/windows-manifest.ts
@@ -14,7 +14,7 @@
  *
  * Cheap on non-Windows: the platform check is the very first statement.
  */
-import { existsSync, utimesSync, writeFileSync } from "node:fs";
+import { utimesSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -72,20 +72,25 @@ export function ensureWindowsManifest(): number {
   }
   let patched = 0;
   for (const exe of getCandidateShimPaths()) {
+    const manifestPath = `${exe}.manifest`;
     try {
-      if (!existsSync(exe)) {
-        continue;
-      }
-      const manifestPath = `${exe}.manifest`;
-      if (existsSync(manifestPath)) {
-        continue;
-      }
-      writeFileSync(manifestPath, MANIFEST, "utf8");
+      // Atomic create — `wx` fails with EEXIST if manifest already present,
+      // so we never overwrite and there is no TOCTOU window. ENOENT here
+      // means the shim's parent dir does not exist (package manager not
+      // installed on this machine), which is the common skip path.
+      writeFileSync(manifestPath, MANIFEST, { encoding: "utf8", flag: "wx" });
+    } catch {
+      // Already exists, parent dir missing, or write denied. Non-fatal.
+      continue;
+    }
+    try {
+      // Bump shim mtime so Windows invalidates its cached elevation decision.
+      // If the shim vanished between write and now, this throws and we skip.
       const now = new Date();
       utimesSync(exe, now, now);
       patched += 1;
     } catch {
-      // Non-fatal. Skip and try next candidate.
+      // Shim gone or unreadable. Manifest is harmless on its own; move on.
     }
   }
   return patched;

--- a/src/windows-manifest.ts
+++ b/src/windows-manifest.ts
@@ -1,0 +1,92 @@
+/**
+ * @module windows-manifest
+ *
+ * Runtime self-heal for the Windows UAC prompt triggered by the bun-generated
+ * `repo-updater.exe` shim. The shim's filename matches Windows' Installer
+ * Detection heuristic (substring "update") and gets auto-elevated on launch
+ * because it has no embedded application manifest.
+ *
+ * Strategy: drop an external `repo-updater.exe.manifest` next to the shim
+ * declaring `asInvoker`, then bump the shim's mtime so Windows invalidates
+ * its cached elevation decision and re-reads the manifest. The first launch
+ * still triggers UAC (we can't act before the OS evaluates the binary), but
+ * every subsequent launch is silent.
+ *
+ * Cheap on non-Windows: the platform check is the very first statement.
+ */
+import { existsSync, utimesSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANIFEST = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity type="win32" name="repo-updater" version="1.0.0.0" processorArchitecture="*"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>
+`;
+
+function getCandidateShimPaths(): string[] {
+  const home = homedir();
+  return [
+    process.env.npm_config_prefix
+      ? join(process.env.npm_config_prefix, "repo-updater.exe")
+      : null,
+    process.env.PNPM_HOME
+      ? join(process.env.PNPM_HOME, "repo-updater.exe")
+      : null,
+    process.env.BUN_INSTALL
+      ? join(process.env.BUN_INSTALL, "bin", "repo-updater.exe")
+      : null,
+    join(home, ".cache", ".bun", "bin", "repo-updater.exe"),
+    join(home, ".bun", "bin", "repo-updater.exe"),
+    join(home, "AppData", "Roaming", "npm", "repo-updater.exe"),
+    join(home, "AppData", "Local", "pnpm", "repo-updater.exe"),
+    join(home, "AppData", "Local", "Yarn", "bin", "repo-updater.exe"),
+  ].filter((p): p is string => typeof p === "string");
+}
+
+/**
+ * Best-effort: ensure the Windows shim has an external asInvoker manifest.
+ * Always swallows errors — never blocks CLI startup.
+ *
+ * @returns Number of shims patched this call (0 if already done or none found).
+ */
+export function ensureWindowsManifest(): number {
+  if (process.platform !== "win32") {
+    return 0;
+  }
+  let patched = 0;
+  for (const exe of getCandidateShimPaths()) {
+    try {
+      if (!existsSync(exe)) {
+        continue;
+      }
+      const manifestPath = `${exe}.manifest`;
+      if (existsSync(manifestPath)) {
+        continue;
+      }
+      writeFileSync(manifestPath, MANIFEST, "utf8");
+      const now = new Date();
+      utimesSync(exe, now, now);
+      patched += 1;
+    } catch {
+      // Non-fatal. Skip and try next candidate.
+    }
+  }
+  return patched;
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     cli: "src/cli.ts",
+    "windows-manifest": "src/windows-manifest.ts",
   },
   format: ["esm"],
   dts: true,


### PR DESCRIPTION
## Summary

- Adds `src/windows-manifest.ts` with `ensureWindowsManifest()` — drops external `repo-updater.exe.manifest` (asInvoker) next to the bun shim and bumps the shim's mtime to invalidate Windows' cached elevation decision.
- Calls it at the top of `cli.ts` so bun-installed users get the fix without needing the postinstall script (which `bun add -g` skips unconditionally).
- Refactors the postinstall script into a thin wrapper around the same module.

## Why

The previous fix (#132) shipped a postinstall that wrote the manifest. Worked for npm/pnpm/yarn but not for `bun add -g` — bun blocks lifecycle scripts for global installs and `trustedDependencies` only governs project deps, not globals. Users installing via bun kept hitting UAC.

Self-heal in `cli.ts` covers the bun gap: first launch still triggers UAC (Windows evaluates the binary before any user-space code runs — unavoidable), but the running process writes the manifest, so every subsequent launch is silent.

## Test plan

- [ ] Build + tests pass locally (`bun run build && bun test`) — confirmed
- [ ] On Windows: `bun rm -g repo-updater && bun add -g <pkg.pr.new url>`
- [ ] Run `repo-updater --help` once — accept UAC
- [ ] Run `repo-updater --help` again — should NOT prompt
- [ ] Verify `~/.cache/.bun/bin/repo-updater.exe.manifest` exists after first run
- [ ] On Linux/macOS: `ensureWindowsManifest()` returns 0 immediately, no fs access

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-heals the Windows UAC prompt for `repo-updater` by writing an `asInvoker` external manifest on first CLI run. Bun globals see UAC once; later launches are silent.

- **Bug Fixes**
  - Run `ensureWindowsManifest()` at CLI start (inside `main()`) to write `repo-updater.exe.manifest` next to the bun shim and bump the shim mtime so Windows re-evaluates it.
  - Use atomic manifest writes (`flag: "wx"`) to avoid race/TOCTOU; safe no-op on non-Windows.

- **Refactors**
  - Extracted manifest + shim discovery into `src/windows-manifest.ts`; exported as `./windows-manifest` and added a build entry in `tsdown.config.ts`.
  - Postinstall now delegates to the built module via a guarded dynamic import, keeping npm/pnpm/yarn installs zero-touch and ignoring missing `dist/`.

<sup>Written for commit f6cf6383bb7457ba65dda70e200433f82c4a862a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows UAC prompts by self-healing `asInvoker` manifest on first CLI invocation
> - Adds [`src/windows-manifest.ts`](https://github.com/mynameistito/repo-updater/pull/134/files#diff-dcb58e8d25b6b8fdfa39cb58a9a80d03b705aeed99ab47b12d117e5146e81478) with `ensureWindowsManifest()`, which writes an external `asInvoker` manifest next to `repo-updater.exe` shims and bumps their mtime to suppress UAC prompts.
> - Calls `ensureWindowsManifest()` at the start of `main()` in [`src/index.ts`](https://github.com/mynameistito/repo-updater/pull/134/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) so the fix applies on the first CLI run without requiring a separate install step.
> - Searches for shims across npm, pnpm, yarn, and bun global install prefixes using environment variables and home-relative defaults.
> - [`scripts/install-windows-manifest.mjs`](https://github.com/mynameistito/repo-updater/pull/134/files#diff-07dcdb1c0f78b011ee396b38b2388d3a5a38b9b73b57a930dfd3c3e1d25d2b5a) (postinstall) now delegates to the same module; it silently no-ops if the dist file is absent (e.g. bun lifecycle skips postinstall).
> - Risk: manifest writes are best-effort and errors are swallowed, so failures will be silent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6cf638.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->