### PR TITLE
fix: suppress Windows UAC prompt and console flash on launch

### DIFF
--- a/.changeset/fix-windows-uac-shim-manifest.md
+++ b/.changeset/fix-windows-uac-shim-manifest.md
@@ -1,0 +1,7 @@
+---
+"repo-updater": patch
+---
+
+Fix Windows UAC prompt and console flash on launch.
+
+The bin name `repo-updater.exe` matches Windows Installer Detection (filename contains "update"), which auto-elevates unsigned `.exe` files without a manifest. A postinstall script now writes an `asInvoker` sidecar manifest next to the installed shim and bumps its mtime to invalidate Windows' cached elevation decision. A runtime self-heal covers `bun add -g`, which skips lifecycle scripts by default. The earlier Bun→Node re-exec in `cli.ts` is removed — it was the source of the terminal flash (spawned `node` via a `.cmd` shim under nvm/fnm/volta).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ pnpm install repo-updater -g                                   # with pnpm
 deno install -g -n repo-updater jsr:@mynameistito/repo-updater/cli # with Deno
 ```
 
+### Windows + `bun add -g` note
+
+Bun skips `postinstall` lifecycle scripts by default. The package ships a postinstall that writes a `repo-updater.exe.manifest` next to the global bin shim — without it, Windows Installer Detection auto-elevates the shim (the filename contains "update") and triggers a UAC prompt plus a console flash on every launch.
+
+Two ways to handle it under bun:
+
+```sh
+bun pm trust repo-updater     # run the postinstall now
+# — or —
+repo-updater --help           # first launch self-heals; one UAC prompt, then silent
+```
+
+npm / pnpm / yarn run the postinstall automatically — no extra step.
+
 ## Usage
 
 ```text

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "repo-updater",
       "dependencies": {
         "@clack/prompts": "^1.3.0",
+        "@types/node": "22.19.15",
         "better-result": "^2.9.2",
         "yaml": "^2.9.0",
       },
@@ -298,7 +299,7 @@
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
-    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260511.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260511.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260511.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260511.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260511.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260511.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260511.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260511.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-cUyY4Sr6065280lB6hCwTMCBMTxlEIGjSLzHym28yikA5sFiEsAzlwiU0i+XkTUIqr5K5M/SzSJiioDN+vpjtA=="],
 
@@ -768,7 +769,7 @@
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
@@ -810,6 +811,8 @@
 
     "ast-kit/@babel/parser": ["@babel/parser@8.0.0-rc.3", "", { "dependencies": { "@babel/types": "^8.0.0-rc.3" }, "bin": "./bin/babel-parser.js" }, "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ=="],
 
+    "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -837,6 +840,8 @@
     "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/deno.json
+++ b/deno.json
@@ -15,6 +15,7 @@
   "imports": {
     "@clack/prompts": "npm:@clack/prompts@^1.3.0",
     "better-result": "npm:better-result@^2.9.2",
-    "yaml": "npm:yaml@^2.9.0"
+    "yaml": "npm:yaml@^2.9.0",
+    "@types/node": "npm:@types/node@22.19.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "node": ">=22.6.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "scripts/install-windows-manifest.mjs"
   ],
   "scripts": {
     "typecheck": "tsgo --noEmit",
@@ -46,11 +47,13 @@
     "fix": "ultracite fix",
     "build": "tsdown",
     "sync:jsr": "bun scripts/sync-jsr-version.ts",
+    "postinstall": "node scripts/install-windows-manifest.mjs",
     "prepublishOnly": "bun run build && bun run typecheck",
     "version": "changeset version && bun run sync:jsr && bunx ultracite fix deno.json"
   },
   "dependencies": {
     "@clack/prompts": "^1.3.0",
+    "@types/node": "22.19.15",
     "better-result": "^2.9.2",
     "yaml": "^2.9.0"
   },

--- a/scripts/install-windows-manifest.mjs
+++ b/scripts/install-windows-manifest.mjs
@@ -78,6 +78,9 @@ for (const dir of candidateBinDirs()) {
     const st = statSync(exe);
     utimesSync(exe, st.atime, new Date());
     wroteAny = true;
+    // Stop after the first successful shim — PATH may contain unrelated
+    // copies (e.g. npm + bun globals) we don't want to mutate.
+    break;
   } catch {
     // Permission denied or similar — skip silently.
   }

--- a/scripts/install-windows-manifest.mjs
+++ b/scripts/install-windows-manifest.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Writes an external `<bin>.exe.manifest` next to the installed Windows shim
+// declaring `requestedExecutionLevel=asInvoker`. Without this, Windows
+// Installer Detection auto-elevates unsigned `.exe` files whose names contain
+// "update" / "install" / "setup" / "patch" — producing a UAC prompt and a
+// console flash on every launch.
+//
+// Also bumps the .exe mtime to invalidate Windows' per-file elevation cache,
+// so the manifest is picked up on the next launch instead of after the next
+// reinstall.
+//
+// Runs as a `postinstall` lifecycle script. Silent no-op on non-Windows and
+// when no shim is found.
+//
+// Note: Bun skips lifecycle scripts by default (security). Users installing
+// via `bun add -g` need `bun pm trust repo-updater` to run this, OR can
+// invoke this script manually:
+//   node <global-bin>/../lib/node_modules/repo-updater/scripts/install-windows-manifest.mjs
+
+import { existsSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
+
+if (process.platform !== "win32") {
+  process.exit(0);
+}
+
+const BIN_NAME = "repo-updater";
+
+const MANIFEST = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>
+`;
+
+function* candidateBinDirs() {
+  // npm / pnpm / yarn — set during lifecycle script execution
+  if (process.env.npm_config_prefix) {
+    yield process.env.npm_config_prefix;
+  }
+  // Bun global bin
+  if (process.env.BUN_INSTALL) {
+    yield join(process.env.BUN_INSTALL, "bin");
+  }
+  if (process.env.USERPROFILE) {
+    yield join(process.env.USERPROFILE, ".bun", "bin");
+  }
+  // PATH fallback — covers volta, fnm, custom installs
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (dir) {
+      yield dir;
+    }
+  }
+}
+
+let wroteAny = false;
+const seen = new Set();
+for (const dir of candidateBinDirs()) {
+  if (seen.has(dir)) {
+    continue;
+  }
+  seen.add(dir);
+
+  const exe = join(dir, `${BIN_NAME}.exe`);
+  if (!existsSync(exe)) {
+    continue;
+  }
+
+  try {
+    writeFileSync(`${exe}.manifest`, MANIFEST);
+    // Bump mtime so Windows treats this as a new file and re-runs Installer
+    // Detection with the manifest present.
+    const st = statSync(exe);
+    utimesSync(exe, st.atime, new Date());
+    wroteAny = true;
+  } catch {
+    // Permission denied or similar — skip silently.
+  }
+}
+
+if (!wroteAny && process.env.npm_config_loglevel === "verbose") {
+  process.stderr.write(`${BIN_NAME}: no .exe shim found; skipped manifest.\n`);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,36 +7,11 @@
  * the process with code 1.
  */
 import { main } from "./index.ts";
+import { selfHealWindowsManifest } from "./windows-manifest.ts";
 
-// `bun add -g` ignores the #!/usr/bin/env node shebang and runs this file
-// under Bun's runtime. On Windows, Bun's node:child_process does not honour
-// windowsHide, so spawning cmd.exe for URL opening creates a visible console
-// window and triggers UAC prompts. Re-exec immediately under Node.js instead.
-if (typeof globalThis.Bun !== "undefined" && process.platform === "win32") {
-  try {
-    const { exitCode } = Bun.spawnSync(["node", ...process.argv.slice(1)], {
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-    // exitCode is null when the process was killed by a signal; treat as failure.
-    process.exit(exitCode ?? 1);
-  } catch (err: unknown) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT" || code === "ERR_ENOENT") {
-      process.stderr.write(
-        "repo-updater: could not find 'node' on PATH.\n" +
-          "Install Node.js (https://nodejs.org) or reinstall this CLI with " +
-          "'npm i -g repo-updater'.\n"
-      );
-    } else {
-      process.stderr.write(
-        `repo-updater: failed to re-exec under Node.js: ${String(err)}\n`
-      );
-    }
-    process.exit(1);
-  }
-}
+// `bun add -g` skips lifecycle scripts by default, so the postinstall
+// manifest may not have been written. Self-heal on first invocation.
+selfHealWindowsManifest();
 
 main().catch((err) => {
   if (err instanceof Error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -656,11 +656,11 @@ export async function openURLs(
     : await detectBrowser(platform, execFn);
   const commands = buildOpenCommands(urls, platform, browserInfo);
 
-  // Always route through openURLNodejs regardless of runtime. On Windows,
-  // Bun's node:child_process ignores windowsHide and triggers UAC prompts,
-  // so cli.ts re-execs under Node.js and all spawns must stay on the Node
-  // path. The POSIX perf impact of skipping the Bun spawn path is negligible.
-  // Do not revert this to a conditional branch between Bun and Node spawn.
+  // Always route through openURLNodejs. In production the `#!/usr/bin/env
+  // node` shebang guarantees the Node runtime (bun's Windows shim respects
+  // it and spawns node.exe directly), so there's no Bun spawn path to worry
+  // about. In dev (`bun run start`) Bun's node:child_process shim still
+  // works, just without windowsHide — fine for local use.
   for (const cmd of commands) {
     await openURLNodejs(cmd);
   }

--- a/src/windows-manifest.ts
+++ b/src/windows-manifest.ts
@@ -1,0 +1,87 @@
+/**
+ * @module windows-manifest
+ *
+ * Writes a sidecar `<exe>.manifest` next to the running launcher on Windows
+ * declaring `requestedExecutionLevel=asInvoker`. This suppresses Windows
+ * Installer Detection auto-elevation, which fires for unsigned `.exe` files
+ * whose names contain "update" / "install" / "setup" / "patch".
+ *
+ * Used as a runtime fallback for installs that skip the `postinstall`
+ * lifecycle script — notably `bun add -g`, which skips scripts unless the
+ * package is trusted.
+ *
+ * Silent no-op on non-Windows, when the manifest already exists, or when the
+ * write fails (read-only install, etc.).
+ */
+
+import { existsSync, statSync, utimesSync, writeFileSync } from "node:fs";
+
+const MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>
+`;
+
+const TRAILING_SLASHES = /[\\/]+$/;
+
+/**
+ * Writes a sidecar asInvoker manifest next to the parent process launcher
+ * (the `.exe` shim that spawned this node process) if one is not already
+ * present. Runs once at startup; cheap when the manifest exists.
+ */
+export function selfHealWindowsManifest(): void {
+  if (process.platform !== "win32") {
+    return;
+  }
+
+  // process.argv[0] is node.exe — not the shim. The shim is the parent.
+  // ppid points at it; its image path is what we need.
+  const shimPath = resolveShimPath();
+  if (!shimPath) {
+    return;
+  }
+
+  const manifestPath = `${shimPath}.manifest`;
+  if (existsSync(manifestPath)) {
+    return;
+  }
+
+  try {
+    writeFileSync(manifestPath, MANIFEST_XML);
+    // Bump mtime so Windows invalidates its cached elevation decision and
+    // re-evaluates with the manifest on the next launch.
+    const st = statSync(shimPath);
+    utimesSync(shimPath, st.atime, new Date());
+  } catch {
+    // Read-only install, permission denied, antivirus lock — give up
+    // silently. User can rerun manually via `bun pm trust repo-updater`.
+  }
+}
+
+function resolveShimPath(): string | null {
+  // The bun/npm shim spawns node and passes the resolved script path as
+  // argv[1]. The shim itself lives next to that script's eventual install
+  // directory, but its actual path isn't exposed via argv.
+  //
+  // Strategy: walk PATH for `repo-updater.exe`. This is the same heuristic
+  // the postinstall script uses, and it works regardless of which package
+  // manager produced the shim.
+  const BIN_NAME = "repo-updater.exe";
+  const dirs = (process.env.PATH ?? "").split(";");
+  for (const dir of dirs) {
+    if (!dir) {
+      continue;
+    }
+    const candidate = `${dir.replace(TRAILING_SLASHES, "")}\\${BIN_NAME}`;
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}

--- a/src/windows-manifest.ts
+++ b/src/windows-manifest.ts
@@ -48,19 +48,18 @@ export function selfHealWindowsManifest(): void {
   }
 
   const manifestPath = `${shimPath}.manifest`;
-  if (existsSync(manifestPath)) {
-    return;
-  }
-
   try {
-    writeFileSync(manifestPath, MANIFEST_XML);
-    // Bump mtime so Windows invalidates its cached elevation decision and
-    // re-evaluates with the manifest on the next launch.
+    // `wx` fails if the file exists. This is the atomic "create-if-absent"
+    // primitive — no TOCTOU window between an existence check and the write.
+    writeFileSync(manifestPath, MANIFEST_XML, { flag: "wx" });
+    // Manifest is new; bump mtime so Windows invalidates its cached
+    // elevation decision and re-evaluates with the manifest on next launch.
     const st = statSync(shimPath);
     utimesSync(shimPath, st.atime, new Date());
   } catch {
-    // Read-only install, permission denied, antivirus lock — give up
-    // silently. User can rerun manually via `bun pm trust repo-updater`.
+    // EEXIST: manifest already in place — common case after first launch.
+    // EACCES / EPERM / EBUSY: read-only install or antivirus lock.
+    // Either way, self-heal is best-effort — swallow and move on.
   }
 }
 


### PR DESCRIPTION
## Summary

- Bin name `repo-updater.exe` matches Windows Installer Detection (filename contains "update"). Bun's shim binary has no embedded asInvoker manifest, so unsigned launches auto-elevate → UAC prompt + console flash on every launch.
- Previous Bun→Node re-exec in `cli.ts` spawned `node` via a `.cmd` shim under nvm/fnm/volta, producing the very flash it was meant to hide. Dropped.
- Postinstall + runtime self-heal write a sidecar `.exe.manifest` (asInvoker) and bump the exe mtime to bust Windows' cached elevation decision.

## Why it broke "around April 26" then suddenly came back

Windows caches Installer Detection decisions per-file (mtime/size keyed). The first install evaluated as asInvoker and was cached. Each subsequent `changeset-release` overwrote the shim → cache busted → eventually re-evaluated as installer → UAC. Commit `b961276` (in the reverted PR #132) is the team's own evidence — its message is literally *"bump exe mtime after manifest write to bust Windows elevation cache"*.

## Changes

- `src/cli.ts` — drop Bun→Node re-exec; call `selfHealWindowsManifest()` at startup.
- `src/windows-manifest.ts` *(new)* — in-process manifest writer + mtime bump. No spawn, no new terminal.
- `scripts/install-windows-manifest.mjs` *(new)* — same logic as a postinstall script. Picked up by npm/pnpm/yarn automatically.
- `package.json` — postinstall hook, ship script in tarball.
- `README.md` — document `bun add -g` lifecycle-script caveat and `bun pm trust repo-updater` remediation.

## Install behavior after this PR

| Install method | UAC | Console flash |
|---|---|---|
| `npm i -g` / `pnpm add -g` / `yarn global add` | Never | Never |
| `bun add -g` + `bun pm trust repo-updater` | Never | Never |
| `bun add -g` (no trust) | One prompt on first launch, then never | Same |

## Test plan

- [x] `bun test` — 176 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean
- [x] `bun run build` — dist bundles `selfHealWindowsManifest`
- [ ] Smoke test on Windows: `bun add -g` from packed tarball → first launch shows UAC once → manifest written → subsequent launches silent
- [ ] Smoke test on Windows: `npm i -g` from packed tarball → postinstall writes manifest → no UAC ever

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Windows UAC prompts and console flashes on launch by adding an `asInvoker` sidecar manifest for the `repo-updater.exe` shim and removing the Bun→Node re-exec. Installs via npm/pnpm/yarn are silent; Bun installs self-heal.

- **Bug Fixes**
  - Add `scripts/install-windows-manifest.mjs` postinstall to write `repo-updater.exe.manifest`, bump the shim mtime, and stop after the first found shim to avoid touching unrelated copies.
  - Add runtime self-heal (`src/windows-manifest.ts`) invoked at CLI startup; uses an atomic write (`flag: 'wx'`) to avoid TOCTOU races and bumps mtime.
  - Remove the Bun→Node re-exec in `src/cli.ts` to eliminate terminal flash; rely on the shebang to run under Node.
  - Update README with Bun trust instructions.

- **Migration**
  - npm/pnpm/yarn: no action needed.
  - Bun: run `bun pm trust repo-updater` to run postinstall, or accept one UAC prompt on first run; subsequent launches are silent.

<sup>Written for commit 8ea7e2c4d64b41af97e4e9810cc5d8e58ff34bc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress Windows UAC prompt and console flash on `repo-updater` launch
> - Adds [scripts/install-windows-manifest.mjs](https://github.com/mynameistito/repo-updater/pull/136/files#diff-07dcdb1c0f78b011ee396b38b2388d3a5a38b9b73b57a930dfd3c3e1d25d2b5a) as a `postinstall` script that writes a sidecar `repo-updater.exe.manifest` with `requestedExecutionLevel=asInvoker` next to the installed shim, and bumps the shim's mtime to invalidate Windows' elevation cache.
> - Adds [src/windows-manifest.ts](https://github.com/mynameistito/repo-updater/pull/136/files#diff-dcb58e8d25b6b8fdfa39cb58a9a80d03b705aeed99ab47b12d117e5146e81478) with `selfHealWindowsManifest()`, called at CLI startup to write the manifest if it's absent, as a fallback for cases where postinstall didn't run (e.g. `bun pm` installs).
> - Removes the Bun→Node re-exec path in [src/cli.ts](https://github.com/mynameistito/repo-updater/pull/136/files#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cdd) on Windows, replacing it with the self-heal call.
> - Behavioral Change: `postinstall` now runs `node scripts/install-windows-manifest.mjs` on all platforms (no-ops on non-Windows); installing via `bun` requires running `bun pm trust repo-updater` or launching the CLI once to trigger the self-heal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ea7e2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->