### PR TITLE
Dep Updates 2026-05-12

### DIFF
--- a/.changeset/dep-updates-1778563879045.md
+++ b/.changeset/dep-updates-1778563879045.md
@@ -1,0 +1,6 @@
+---
+"repo-updater": patch
+---
+
+Updated dependencies:
+- @types/node: 22.19.15 → 25.7.0

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "repo-updater",
       "dependencies": {
         "@clack/prompts": "^1.3.0",
-        "@types/node": "22.19.15",
+        "@types/node": "25.7.0",
         "better-result": "^2.9.2",
         "yaml": "^2.9.0",
       },
@@ -299,7 +299,7 @@
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
-    "@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260511.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260511.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260511.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260511.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260511.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260511.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260511.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260511.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-cUyY4Sr6065280lB6hCwTMCBMTxlEIGjSLzHym28yikA5sFiEsAzlwiU0i+XkTUIqr5K5M/SzSJiioDN+vpjtA=="],
 
@@ -769,7 +769,7 @@
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 

--- a/deno.json
+++ b/deno.json
@@ -16,6 +16,6 @@
     "@clack/prompts": "npm:@clack/prompts@^1.3.0",
     "better-result": "npm:better-result@^2.9.2",
     "yaml": "npm:yaml@^2.9.0",
-    "@types/node": "npm:@types/node@22.19.15"
+    "@types/node": "npm:@types/node@25.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.3.0",
-    "@types/node": "22.19.15",
+    "@types/node": "25.7.0",
     "better-result": "^2.9.2",
     "yaml": "^2.9.0"
   },


### PR DESCRIPTION
Dep Updates 2026-05-12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Node.js type definitions to `@types/node` 25.7.0 across the repo to keep typings current. No runtime changes; types and lockfile only.

- **Dependencies**
  - Bump `@types/node` from 22.19.15 to 25.7.0 in `package.json` and `deno.json`.
  - Lockfile updated; transitive `undici-types` moves to 7.21.0.

<sup>Written for commit 1ae9a4ac8969539dbc364a114fa51159166a0170. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `@types/node` from 22.19.15 to 25.7.0
> Bumps `@types/node` across [package.json](https://github.com/mynameistito/repo-updater/pull/138/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [deno.json](https://github.com/mynameistito/repo-updater/pull/138/files#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7c), and [bun.lock](https://github.com/mynameistito/repo-updater/pull/138/files#diff-bfd0ef82a01108fa1e836c2500b98b7de8a92bb1ae352a8efcbd9d6ffcaabd60). Also updates `undici-types` from 6.21.0 to 7.21.0 as a transitive dependency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ae9a4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->