### PR TITLE
Dep Updates 2026-05-26

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -16,6 +16,6 @@
     "@clack/prompts": "npm:@clack/prompts@^1.4.0",
     "better-result": "npm:better-result@^2.9.2",
     "yaml": "npm:yaml@^2.9.0",
-    "@types/node": "npm:@types/node@25.8.0"
+    "@types/node": "npm:@types/node@25.9.1"
   }
 }


### PR DESCRIPTION
Dep Updates 2026-05-26

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `@types/node` from 25.8.0 to 25.9.1 in deno.json to pick up the latest Node type definitions and fixes. Dev-only change with no runtime impact.

<sup>Written for commit f2bbd82d1475bebffd80b14c23fd12f1a619bbc8. Summary will update on new commits. <a href="https://cubic.dev/pr/mynameistito/repo-updater/pull/147?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `@types/node` dependency from 25.8.0 to 25.9.1
> Bumps the `@types/node` mapped dependency in [deno.json](https://github.com/mynameistito/repo-updater/pull/147/files#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7c) to the latest minor release.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2bbd82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->