### PR TITLE
chore: publish npm releases to staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment: npm stage publish
+    env:
+      NPM_DIST_TAG: staging
     permissions:
       contents: write
       pull-requests: write
@@ -46,14 +48,14 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: bun run version
-          publish: bunx changeset publish --tag staging
+          publish: bunx changeset publish --tag ${{ env.NPM_DIST_TAG }}
           commit: "chore: version packages"
           title: "chore: version packages"
-          createGithubReleases: true
+          createGithubReleases: ${{ env.NPM_DIST_TAG != 'staging' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Publish to JSR
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' && env.NPM_DIST_TAG != 'staging'
         run: npx jsr publish --allow-slow-types

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     name: Release
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    environment: npm stage publish
     permissions:
       contents: write
       pull-requests: write
@@ -45,7 +46,7 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: bun run version
-          publish: bunx changeset publish
+          publish: bunx changeset publish --tag staging
           commit: "chore: version packages"
           title: "chore: version packages"
           createGithubReleases: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,61 +1,147 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
+  push:
+    branches:
+      - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
-  cancel-in-progress: false
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Release
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    environment: npm stage publish
-    env:
-      NPM_DIST_TAG: staging
     permissions:
       contents: write
-      pull-requests: write
       id-token: write
+      pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: lts/*
-
-      - name: Upgrade npm for OIDC Trusted Publishing
-        run: npm install -g npm@11.12.0
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Update npm
+        run: npm install --global npm@latest
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Create release PR or publish
+      - name: Build
+        run: bun run build
+
+      - name: Create release pull request
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          version: bun run version
-          publish: bunx changeset publish --tag ${{ env.NPM_DIST_TAG }}
-          commit: "chore: version packages"
-          title: "chore: version packages"
-          createGithubReleases: ${{ env.NPM_DIST_TAG != 'staging' }}
+          version: bunx changeset version
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          NPM_CONFIG_PROVENANCE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to JSR
-        if: steps.changesets.outputs.published == 'true' && env.NPM_DIST_TAG != 'staging'
-        run: npx jsr publish --allow-slow-types
+      - name: Read package metadata
+        id: package
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          package_name=$(node --print "require('./package.json').name")
+          package_version=$(node --print "require('./package.json').version")
+
+          echo "name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "version=$package_version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$package_version" >> "$GITHUB_OUTPUT"
+
+      - name: Publish package
+        id: publish
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          package_name="${{ steps.package.outputs.name }}"
+          package_version="${{ steps.package.outputs.version }}"
+          package_spec="$package_name@$package_version"
+
+          if npm view "$package_spec" version >/dev/null 2>&1; then
+            echo "$package_spec is already published"
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          staged_json=$(npm stage list "$package_name" --json 2>/dev/null || true)
+          if STAGED_JSON="$staged_json" PACKAGE_VERSION="$package_version" node --input-type=module <<'EOF'
+          const input = process.env.STAGED_JSON?.trim();
+          if (!input) {
+            process.exit(1);
+          }
+
+          let parsed;
+          try {
+            parsed = JSON.parse(input);
+          } catch {
+            process.exit(1);
+          }
+
+          if (parsed?.error) {
+            process.exit(1);
+          }
+
+          const version = process.env.PACKAGE_VERSION;
+          const staged = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {});
+          const hasVersion = staged.some((entry) => {
+            if (typeof entry === "string") {
+              return entry === version || entry.endsWith(`@${version}`);
+            }
+
+            if (!entry || typeof entry !== "object") {
+              return false;
+            }
+
+            return entry.version === version || entry.package?.version === version;
+          });
+
+          process.exit(hasVersion ? 0 : 1);
+          EOF
+          then
+            echo "$package_spec is already staged for approval"
+            echo "staged=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          npm stage publish . --access public --provenance
+          echo "staged=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.changesets.outputs.hasChangesets == 'false' && (steps.publish.outputs.published == 'true' || steps.publish.outputs.staged == 'true')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          node --input-type=module <<'EOF' > release-notes.md
+          const fs = await import("node:fs/promises");
+          const changelog = await fs.readFile("CHANGELOG.md", "utf8");
+          const heading = `## ${process.env.PACKAGE_VERSION}`;
+          const start = changelog.indexOf(heading);
+          const bodyStart = start === -1 ? -1 : changelog.indexOf("\n", start) + 1;
+          const nextHeading = bodyStart === -1 ? -1 : changelog.indexOf("\n## ", bodyStart);
+          const notes = bodyStart === -1
+            ? `Release ${process.env.PACKAGE_VERSION}`
+            : changelog.slice(bodyStart, nextHeading === -1 ? undefined : nextHeading).trim();
+
+          console.log(notes);
+          EOF
+
+          if gh release view "${{ steps.package.outputs.tag }}" >/dev/null 2>&1; then
+            echo "GitHub release ${{ steps.package.outputs.tag }} already exists"
+            exit 0
+          fi
+
+          gh release create "${{ steps.package.outputs.tag }}" \
+            --target "$GITHUB_SHA" \
+            --title "${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}" \
+            --notes-file release-notes.md


### PR DESCRIPTION
## Summary
- bind the release job to the npm staging GitHub environment for Trusted Publishing
- publish npm releases with the staging dist-tag instead of latest
- keep GitHub Releases and JSR publishing behavior unchanged

## Changeset
- Not added: this is release infrastructure only and does not change package contents or user-facing behavior.

## Validation
- pre-commit hook validated .github/workflows/release.yml with v8r

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish npm releases to the staging channel using `npm stage publish`, with the workflow now triggered on pushes to `main` and building with Bun/Node. Changesets only opens the version PR; if no PR is needed we stage the package (or skip if already published/staged) and auto-create a GitHub Release; JSR publishing is removed.

<sup>Written for commit e224714e28fad74311e04d9f09a3fc8838c90184. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/repo-updater/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish npm releases to staging via custom workflow steps
> - Replaces the changesets-based publish flow with a custom multi-step approach: version via changesets, check if the version is already published or staged, then conditionally stage-publish to npm with provenance
> - Switches workflow trigger from `workflow_run` (on CI completion) to `push` on `main`, removing the gate on upstream CI success
> - Adds Bun setup and an explicit build step; bumps actions to checkout v7, setup-node v6.4.0, and Node 24
> - Replaces automatic GitHub release creation via changesets with a custom step that extracts release notes from `CHANGELOG.md`
> - Risk: Several YAML keys and a `bun install` flag contain the literal string `&-;` (e.g. `runs&-;on`), which will produce invalid YAML keys and likely break workflow execution entirely
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e224714.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->