### PR TITLE
fix: fall back when origin HEAD is unavailable

### DIFF
--- a/.changeset/bright-falcons-fix.md
+++ b/.changeset/bright-falcons-fix.md
@@ -1,0 +1,5 @@
+---
+"repo-updater": patch
+---
+
+Fix default-branch detection when `origin/HEAD` is not a symbolic ref.

--- a/__tests__/runner.test.ts
+++ b/__tests__/runner.test.ts
@@ -121,6 +121,47 @@ BunTest.describe("updateRepo", () => {
   );
 
   BunTest.test(
+    "falls back to main when origin HEAD is not a symbolic ref",
+    async () => {
+      const executedCmds: string[][] = [];
+      const mockExec = (
+        cmd: string[],
+        _cwd: string
+      ): Promise<Result<ExecOutput, CommandFailedError>> => {
+        executedCmds.push(cmd);
+        if (
+          cmd[0] === "git" &&
+          cmd[1] === "symbolic-ref" &&
+          cmd[2] === "refs/remotes/origin/HEAD"
+        ) {
+          return Promise.resolve(
+            Result.err(
+              new CommandFailedError({
+                command: "git symbolic-ref refs/remotes/origin/HEAD",
+                message: "origin HEAD is not a symbolic ref",
+                stderr:
+                  "fatal: ref refs/remotes/origin/HEAD is not a symbolic ref",
+              })
+            )
+          );
+        }
+        if (cmd[0] === "git" && cmd[1] === "status") {
+          return ok();
+        }
+        return ok();
+      };
+
+      const result = await updateRepo(
+        { date: "2025-01-01", dryRun: false, repo: tempDir },
+        mockExec
+      );
+
+      BunTest.expect(result.isOk()).toBe(true);
+      BunTest.expect(executedCmds).toContainEqual(["git", "checkout", "main"]);
+    }
+  );
+
+  BunTest.test(
     "non-dry-run returns pr-created with URL when changes exist",
     async () => {
       const prUrl = "https://github.com/owner/repo/pull/42";

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -706,13 +706,16 @@ export const updateRepo = (
 
     // Detect default branch dynamically
     let defaultBranch = "main";
-    const defaultBranchResult = yield* Result.await(
-      execFn(["git", "symbolic-ref", "refs/remotes/origin/HEAD"], repo)
+    const defaultBranchResult = await execFn(
+      ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+      repo
     );
-    const defaultBranchMatch =
-      defaultBranchResult.stdout.match(DEFAULT_BRANCH_REGEX);
-    if (defaultBranchMatch) {
-      [, defaultBranch] = defaultBranchMatch;
+    if (defaultBranchResult.isOk()) {
+      const defaultBranchMatch =
+        defaultBranchResult.value.stdout.match(DEFAULT_BRANCH_REGEX);
+      if (defaultBranchMatch) {
+        [, defaultBranch] = defaultBranchMatch;
+      }
     }
 
     console.log(`[info] Using default branch: ${defaultBranch}`);


### PR DESCRIPTION
## Summary
- Continue updates with the existing `main` fallback when `origin/HEAD` is not a symbolic ref.
- Add regression coverage for Git's exit-128 response.
- Add a patch changeset for `repo-updater`.

## Validation
- `bun test __tests__/runner.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run test:node`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix default-branch detection to fall back to main when `origin/HEAD` isn't a symbolic ref. Adds regression tests and a patch release for `repo-updater`.

- **Bug Fixes**
  - Use `main` when `git symbolic-ref refs/remotes/origin/HEAD` errors (e.g., exit 128) or isn’t symbolic.
  - Parse the branch name only when the command succeeds.
  - Added tests to verify the fallback and ensure `git checkout main` is used.

<sup>Written for commit 212a619f3e3a22219dd04c20b989b4c44d3504a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/repo-updater/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix default-branch detection in `updateRepo` when `origin/HEAD` is not a symbolic ref
> Previously, `updateRepo` in [runner.ts](https://github.com/mynameistito/repo-updater/pull/170/files#diff-d64beacb5711e9646c8e8e25cf23f283358d86c7f5f50b6f3aaf18044e356942) propagated errors from `git symbolic-ref refs/remotes/origin/HEAD` rather than falling back gracefully. Now it checks whether the result is `Ok` before parsing stdout, keeping `"main"` as the default branch on failure so that `git checkout main` can proceed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 212a619.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->